### PR TITLE
[SDK-128]: Updated HTTP header to X-Yoti-SDK

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <config>
-    <add key="repositoryPath" value="$\..\Packages" />
+    <add key="repositoryPath" value="$\..\packages" />
   </config>
 </configuration>

--- a/src/Example/Example.csproj
+++ b/src/Example/Example.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.0\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props" Condition="Exists('..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.0\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" />
-  <Import Project="..\..\packages\Microsoft.Net.Compilers.1.0.0\build\Microsoft.Net.Compilers.props" Condition="Exists('..\..\packages\Microsoft.Net.Compilers.1.0.0\build\Microsoft.Net.Compilers.props')" />
+  <Import Project="..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.7\build\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props" Condition="Exists('..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.7\build\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" />
+  <Import Project="..\..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props" Condition="Exists('..\..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -61,9 +61,8 @@
       <HintPath>..\..\packages\Google.Protobuf.3.0.0\lib\net45\Google.Protobuf.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.0\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.7\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -270,8 +269,8 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Microsoft.Net.Compilers.1.0.0\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Net.Compilers.1.0.0\build\Microsoft.Net.Compilers.props'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.0\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.0\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.7\build\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.7\build\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Example/Example.csproj
+++ b/src/Example/Example.csproj
@@ -153,7 +153,7 @@
       <HintPath>..\..\packages\Antlr.3.4.1.9004\lib\Antlr3.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="Yoti.Auth, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Yoti.2.1.0\lib\net451\Yoti.Auth.dll</HintPath>
+      <HintPath>..\..\packages\Yoti.2.1.1\lib\net451\Yoti.Auth.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Example/Web.config
+++ b/src/Example/Web.config
@@ -51,12 +51,6 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-  <system.codedom>
-    <compilers>
-      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:6 /nowarn:1659;1699;1701" />
-      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:14 /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
-    </compilers>
-  </system.codedom>
   <entityFramework>
     <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
       <parameters>
@@ -67,4 +61,10 @@
       <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
     </providers>
   </entityFramework>
+  <system.codedom>
+    <compilers>
+      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:6 /nowarn:1659;1699;1701" />
+      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:14 /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
+    </compilers>
+  </system.codedom>
 </configuration>

--- a/src/Example/packages.config
+++ b/src/Example/packages.config
@@ -10,9 +10,9 @@
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net451" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net451" />
-  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.0" targetFramework="net451" />
+  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.7" targetFramework="net451" />
   <package id="Microsoft.jQuery.Unobtrusive.Validation" version="3.2.3" targetFramework="net451" />
-  <package id="Microsoft.Net.Compilers" version="1.0.0" targetFramework="net451" developmentDependency="true" />
+  <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net451" developmentDependency="true" />
   <package id="Microsoft.Owin" version="3.0.1" targetFramework="net451" />
   <package id="Microsoft.Owin.Host.SystemWeb" version="3.0.1" targetFramework="net451" />
   <package id="Microsoft.Owin.Security" version="3.0.1" targetFramework="net451" />

--- a/src/Example/packages.config
+++ b/src/Example/packages.config
@@ -37,5 +37,5 @@
   <package id="System.Threading" version="4.0.11" targetFramework="net451" />
   <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net451" />
   <package id="WebGrease" version="1.5.2" targetFramework="net451" />
-  <package id="Yoti" version="2.1.0" targetFramework="net451" />
+  <package id="Yoti" version="2.1.1" targetFramework="net451" />
 </packages>

--- a/src/Yoti.Auth.nuspec
+++ b/src/Yoti.Auth.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Yoti</id>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
     <authors>Yoti</authors>
     <owners>Yoti</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/src/Yoti.Auth/YotiClientEngine.cs
+++ b/src/Yoti.Auth/YotiClientEngine.cs
@@ -58,7 +58,7 @@ namespace Yoti.Auth
             {
                 { "X-Yoti-Auth-Key", authKey },
                 { "X-Yoti-Auth-Digest", authDigest },
-                { "X-SDK", sdkIdentifier }
+                { "X-Yoti-SDK", sdkIdentifier }
             };
 
             var response = await _httpRequester.DoRequest(


### PR DESCRIPTION
1. Changed header to X-Yoti-SDK
2. Published new NuGet package
3. Updated example project to use this new package
4. Fixed error with Package Manager Console inside the example project ([SO1](https://stackoverflow.com/questions/41901031/error-packagemanager-console), [SO2](https://stackoverflow.com/questions/31770339/nuget-package-manager-update-3-1-1-0-broken/32402220#32402220))
5. Minor change to casing of NuGet package folder, as this is the casing that is currently set in the example projects
