### PR TITLE
SDK-881: Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: csharp
+mono: none
+solution: Yoti.Auth.sln
+os: windows
+  
+before_install:
+- cd src
+
+install:
+- dotnet restore ../test/Yoti.Auth.Tests/Yoti.Auth.Tests.csproj
+
+script:
+- dotnet test -c Release --verbosity normal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Yoti .NET SDK
 =============
 
+[![Build Status](https://travis-ci.com/getyoti/yoti-dotnet-sdk.svg?branch=master)](https://travis-ci.com/getyoti/yoti-dotnet-sdk)
+
 Welcome to the Yoti .NET SDK. This repo contains the tools and step by step instructions you need to quickly integrate your .NET back-end with Yoti so that your users can share their identity details with your application in a secure and trusted way.
 
 ## Table of Contents

--- a/src/Examples/45Example/45Example.csproj
+++ b/src/Examples/45Example/45Example.csproj
@@ -235,13 +235,8 @@
       <Name>Yoti.Auth</Name>
     </ProjectReference>
   </ItemGroup>
-  <PropertyGroup>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
-    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
-  </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
   <Target Name="MvcBuildViews" AfterTargets="AfterBuild" Condition="'$(MvcBuildViews)'=='true'">
     <AspNetCompiler VirtualPath="temp" PhysicalPath="$(WebProjectOutputDir)" />
   </Target>

--- a/src/Yoti.Auth/Yoti.Auth.csproj
+++ b/src/Yoti.Auth/Yoti.Auth.csproj
@@ -17,7 +17,7 @@
     <PackageIconUrl>https://static.yoti.com/images/logo.svg</PackageIconUrl>
     <RepositoryUrl>https://github.com/getyoti/yoti-dotnet-sdk</RepositoryUrl>
     <PackageTags>yoti 2FA multifactor authentication verification identity login register verify 2Factor sdk</PackageTags>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <LangVersion>latest</LangVersion>
     <Version>3.0.0</Version>
   </PropertyGroup>

--- a/test/Yoti.Auth.Tests/Yoti.Auth.Tests.csproj
+++ b/test/Yoti.Auth.Tests/Yoti.Auth.Tests.csproj
@@ -12,6 +12,7 @@
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <DebugType>Full</DebugType>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Since the SDK builds against multiple frameworks, some of which are only available on Windows, we need to have Windows as the OS.
- Modification to the .csproj file is removing a property that VS 2012 added, which isn't needed (and was causing the build to fail on Travis) ([SO answer here](https://stackoverflow.com/questions/19718281/external-vs2013-build-error-error-msb4019-the-imported-project-path-was-not))
- `<IsTestProject>` is required to tell the dotnet compiler that tests should be run for that project. I'm following the issue which will allow us to suppress the output which produces: `Skipping running test for project C:\Users\travis\build\getyoti\yoti-dotnet-sdk\src\Yoti.Auth\Yoti.Auth.csproj. To run tests with dotnet test add "<IsTestProject>true<IsTestProject>" property to project file.` for each Framework, as this is unwanted noise.
- There was a flag to generate the NuGet package on build. Obviously we don't want this to run every time in CI, so have set this to false, and we will generate manually when needed. 

[![Build Status](https://travis-ci.com/getyoti/yoti-dotnet-sdk.svg?branch=SDK-881-Travis)](https://travis-ci.com/getyoti/yoti-dotnet-sdk)