### PR TITLE
SDK-893: Update UNDEFINED Content type handling

### DIFF
--- a/src/Yoti.Auth/ProfileParser.cs
+++ b/src/Yoti.Auth/ProfileParser.cs
@@ -18,7 +18,7 @@ namespace Yoti.Auth
                 Response.CreateExceptionFromStatusCode<YotiProfileException>(response);
             }
 
-            if (response.Content == null)
+            if (string.IsNullOrEmpty(response.Content))
             {
                 throw new YotiProfileException("The content of the response is null");
             }
@@ -65,10 +65,7 @@ namespace Yoti.Auth
                     profileContent,
                     keyPair);
 
-                foreach (ProtoBuf.Attribute.Attribute attribute in profileAttributeList.Attributes)
-                {
-                    parsedAttributes.Add(attribute.Name, AttributeConverter.ConvertToBaseAttribute(attribute));
-                }
+                parsedAttributes = AttributeConverter.ConvertToBaseAttributes(profileAttributeList);
             }
 
             return parsedAttributes;

--- a/src/Yoti.Auth/Yoti.Auth.csproj
+++ b/src/Yoti.Auth/Yoti.Auth.csproj
@@ -29,6 +29,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="NLog" Version="4.6.3" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.2" />
   </ItemGroup>
 

--- a/test/Yoti.Auth.Tests/ActivityTests.cs
+++ b/test/Yoti.Auth.Tests/ActivityTests.cs
@@ -17,7 +17,6 @@ namespace Yoti.Auth.Tests
     {
         private YotiProfile _yotiProfile;
         private JToken _dictionaryObject = null;
-        private ProtoBuf.Attribute.AttributeList _attributeList;
 
         private const string AddressFormatJson = "address_format";
         private const string BuildingNumberJson = "building_number";
@@ -49,7 +48,6 @@ namespace Yoti.Auth.Tests
         public void Startup()
         {
             _yotiProfile = new YotiProfile();
-            _attributeList = new ProtoBuf.Attribute.AttributeList();
         }
 
         [TestMethod]
@@ -640,7 +638,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void AddAttributesToProfile_UndefinedContentType_IsNotAdded()
+        public void AddAttributesToProfile_UndefinedContentType_ConvertedToString()
         {
             var attribute = new ProtoBuf.Attribute.Attribute
             {
@@ -651,7 +649,7 @@ namespace Yoti.Auth.Tests
 
             AddAttributeToProfile<string>(attribute);
 
-            Assert.IsNull(_yotiProfile.FamilyName);
+            Assert.AreEqual(StringValue, _yotiProfile.FamilyName.GetValue());
         }
 
         [TestMethod]

--- a/test/Yoti.Auth.Tests/AttributeConverterTests.cs
+++ b/test/Yoti.Auth.Tests/AttributeConverterTests.cs
@@ -1,0 +1,41 @@
+﻿using Google.Protobuf;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Yoti.Auth.Tests
+{
+    [TestClass]
+    public class AttributeConverterTests
+    {
+        private const string StringValue = "{}";
+        private readonly ByteString _byteValue = ByteString.CopyFromUtf8(StringValue);
+
+        [TestMethod]
+        public void FailureInAttributeParsing_ShouldNotStopOtherAttributes()
+        {
+            var attribute1 = CreateProtobufJsonAttribute(Constants.UserProfile.StructuredPostalAddressAttribute, _byteValue);
+            var invalidAttribute = CreateProtobufJsonAttribute(Constants.UserProfile.PostalAddressAttribute, ByteString.CopyFromUtf8("invalid"));
+            var attribute2 = CreateProtobufJsonAttribute(Constants.UserProfile.PhoneNumberAttribute, _byteValue);
+
+            var attributeList = new ProtoBuf.Attribute.AttributeList
+            {
+                Attributes = { attribute1, invalidAttribute, attribute2 }
+            };
+
+            var result = AttributeConverter.ConvertToBaseAttributes(attributeList);
+
+            Assert.AreEqual(2, result.Count);
+            Assert.IsTrue(result.ContainsKey(Constants.UserProfile.StructuredPostalAddressAttribute));
+            Assert.IsTrue(result.ContainsKey(Constants.UserProfile.PhoneNumberAttribute));
+        }
+
+        private ProtoBuf.Attribute.Attribute CreateProtobufJsonAttribute(string name, ByteString value)
+        {
+            return new ProtoBuf.Attribute.Attribute
+            {
+                Name = name,
+                ContentType = ProtoBuf.Attribute.ContentType.Json,
+                Value = value
+            };
+        }
+    }
+}

--- a/test/Yoti.Auth.Tests/ProfileParserTests.cs
+++ b/test/Yoti.Auth.Tests/ProfileParserTests.cs
@@ -1,0 +1,45 @@
+﻿using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Org.BouncyCastle.Crypto;
+using Yoti.Auth.Exceptions;
+
+namespace Yoti.Auth.Tests
+{
+    [TestClass]
+    public class ProfileParserTests
+    {
+        private static AsymmetricCipherKeyPair GetKey()
+        {
+            return CryptoEngine.LoadRsaKey(File.OpenText("test-key.pem"));
+        }
+
+        [TestMethod]
+        public void UnsuccessfulResponseThrowsYotiProfileException()
+        {
+            var response = new Response
+            {
+                Success = false
+            };
+
+            Assert.ThrowsException<YotiProfileException>(() =>
+            {
+                ProfileParser.HandleResponse(GetKey(), response);
+            });
+        }
+
+        [TestMethod]
+        public void NullOrEmptyContentThrowsProfileException()
+        {
+            var response = new Response
+            {
+                Success = true,
+                Content = ""
+            };
+
+            Assert.ThrowsException<YotiProfileException>(() =>
+            {
+                ProfileParser.HandleResponse(GetKey(), response);
+            });
+        }
+    }
+}


### PR DESCRIPTION
- Testing that the remaining attributes continue to be parsed required a small amount of reorganising.
- I also noticed there was no test coverage for the exceptions in ProfileParser, so I added those. 
- Using [NLog](https://nlog-project.org/) in favour of other logging tools as it is open-source, seems to be the de facto standard, and is actively maintained. It also seems to be the [most efficient](https://www.loggly.com/blog/benchmarking-5-popular-net-logging-libraries/). We are using the MS logging in the example projects, so I will look at swapping that out in future. 