### PR TITLE
SDK-694: DateTimes & Descriptions

### DIFF
--- a/src/Yoti.Auth/Document/DocumentDetails.cs
+++ b/src/Yoti.Auth/Document/DocumentDetails.cs
@@ -6,7 +6,7 @@ namespace Yoti.Auth.Document
     public class DocumentDetails
     {
         /// <summary>
-        /// 3 digit country code, e.g. “GBR“
+        /// ISO-3166-1 alpha-3 country code, e.g. “GBR“
         /// </summary>
         public string IssuingCountry { get; private set; }
 

--- a/src/Yoti.Auth/Document/DocumentDetails.cs
+++ b/src/Yoti.Auth/Document/DocumentDetails.cs
@@ -5,10 +5,31 @@ namespace Yoti.Auth.Document
 {
     public class DocumentDetails
     {
+        /// <summary>
+        /// 3 digit country code, e.g. “GBR“
+        /// </summary>
         public string IssuingCountry { get; private set; }
+
+        /// <summary>
+        /// Document number (may include letters) from the document.
+        /// </summary>
         public string DocumentNumber { get; private set; }
+
+        /// <summary>
+        /// Expiration date of the document in DateTime format.
+        /// If the document does not expire, this field will not be present.
+        /// The time part of this DateTime will default to 00:00:00.
+        /// </summary>
         public DateTime? ExpirationDate { get; private set; }
+
+        /// <summary>
+        ///  Type of the document e.g. PASSPORT | DRIVING_LICENCE | NATIONAL_ID | PASS_CARD
+        /// </summary>
         public string DocumentType { get; private set; }
+
+        /// <summary>
+        /// Can either be a country code (for a state), or the name of the issuing authority.
+        /// </summary>
         public string IssuingAuthority { get; private set; }
 
         public DocumentDetails(string documentType, string issuingCountry, string documentNumber, DateTime? expirationDate, string issuingAuthority)

--- a/src/Yoti.Auth/YotiProfile.cs
+++ b/src/Yoti.Auth/YotiProfile.cs
@@ -94,7 +94,7 @@ namespace Yoti.Auth
         }
 
         /// <summary>
-        /// DateOfBirth represents the user's date of birth. This will be null if not provided by Yoti.
+        /// DateOfBirth represents the user's date of birth as a DateTime. The time part of this DateTime will default to 00:00:00. This will be null if not provided by Yoti.
         /// </summary>
         public YotiAttribute<DateTime> DateOfBirth
         {


### PR DESCRIPTION
- See ticket SDK-694 for more info - have opted to not make any other changes as part of that ticket
- Added to descriptions of DateTime objects to explain the times will default to 00:00:00
- Added remaining DocumentDetails descriptions - please review