### PR TITLE
FXCop

### DIFF
--- a/src/Examples/45Example/App_Start/FilterConfig.cs
+++ b/src/Examples/45Example/App_Start/FilterConfig.cs
@@ -2,7 +2,7 @@
 
 namespace Example
 {
-    public class FilterConfig
+    public static class FilterConfig
     {
         public static void RegisterGlobalFilters(GlobalFilterCollection filters)
         {

--- a/src/Examples/45Example/App_Start/RouteConfig.cs
+++ b/src/Examples/45Example/App_Start/RouteConfig.cs
@@ -3,7 +3,7 @@ using System.Web.Routing;
 
 namespace Example
 {
-    public class RouteConfig
+    public static class RouteConfig
     {
         public static void RegisterRoutes(RouteCollection routes)
         {

--- a/src/Examples/CoreExample/CoreExample.csproj
+++ b/src/Examples/CoreExample/CoreExample.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="DotNetEnv" Version="1.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.1.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.0.0" />
@@ -33,7 +33,6 @@
     <Folder Include="https\" />
   </ItemGroup>
 
-
   <ItemGroup>
     <None Update="https\CoreExample.pfx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -43,5 +42,4 @@
   <ItemGroup>
     <Folder Include="wwwroot\static\assets\icons\" />
   </ItemGroup>
-
 </Project>

--- a/src/Yoti.Auth/ShareUrl/Policy/DynamicPolicy.cs
+++ b/src/Yoti.Auth/ShareUrl/Policy/DynamicPolicy.cs
@@ -17,8 +17,12 @@ namespace Yoti.Auth.ShareUrl.Policy
         [JsonProperty(PropertyName = "wanted_remember_me")]
         private readonly bool _wantedRememberMeId;
 
+#pragma warning disable 0414 //"Value never used" warning: the JsonProperty is used when creating the DynamicPolicy JSON
+
         [JsonProperty(PropertyName = "wanted_remember_me_optional")]
         private readonly bool _isWantedRememberMeIdOptional;
+
+#pragma warning restore 0414
 
         public DynamicPolicy(
             ICollection<WantedAttribute> wantedAttributes,

--- a/src/Yoti.Auth/ShareUrl/Policy/WantedAttribute.cs
+++ b/src/Yoti.Auth/ShareUrl/Policy/WantedAttribute.cs
@@ -10,8 +10,12 @@ namespace Yoti.Auth.ShareUrl.Policy
         [JsonProperty(PropertyName = "derivation")]
         private readonly string _derivation;
 
+#pragma warning disable 0414 //"Value never used" warning: the JsonProperty is used when creating the DynamicPolicy JSON
+
         [JsonProperty(PropertyName = "optional")]
         private readonly bool _optional;
+
+#pragma warning restore 0414
 
         public WantedAttribute(string name, string derivation)
         {

--- a/test/Yoti.Auth.Tests/TestData/TestAnchors.cs
+++ b/test/Yoti.Auth.Tests/TestData/TestAnchors.cs
@@ -1,6 +1,6 @@
 ﻿namespace Yoti.Auth.Tests.TestData
 {
-    internal class TestAnchors
+    internal static class TestAnchors
     {
         public static readonly string DrivingLicenseAnchor =
             "CjdBTkMtRE9Dz8qdV2DSwFJicqASUbdSRfmYOsJzswHQ4hDnfOUXtYeRlVOeQnVr3an"

--- a/test/Yoti.Auth.Tests/TestTools/Anchors.cs
+++ b/test/Yoti.Auth.Tests/TestTools/Anchors.cs
@@ -4,7 +4,7 @@ using Yoti.Auth.ProtoBuf.Attribute;
 
 namespace Yoti.Auth.Tests.TestTools
 {
-    internal class Anchors
+    internal static class Anchors
     {
         public static ProtoBuf.Attribute.Attribute BuildAnchoredAttribute(string name, string value, ContentType contentType, string rawAnchor)
         {

--- a/test/Yoti.Auth.Tests/Yoti.Auth.Tests.csproj
+++ b/test/Yoti.Auth.Tests/Yoti.Auth.Tests.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
     <PackageReference Include="OpenCover" Version="4.7.922" />
     <PackageReference Include="ReportGenerator" Version="4.1.5" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Yoti.Auth.Tests/YotiClientTests.cs
+++ b/test/Yoti.Auth.Tests/YotiClientTests.cs
@@ -20,12 +20,6 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void YotiClient_ValidParameters_DoesntThrowException()
-        {
-            CreateYotiClient();
-        }
-
-        [TestMethod]
         public void YotiClient_NullSdkId_ThrowsException()
         {
             StreamReader keystream = GetValidKeyStream();


### PR DESCRIPTION
- Changed reference to AspNetCore.All to not specify a version (see <https://docs.microsoft.com/en-gb/dotnet/core/tools/csproj#implicit-package-references>)
- Made FXCop suggestions
- Added suppression inline for variable not being used - since we might be reinstating the value (and so the use of it) at a later date
- Removed redundant test - this method is being called in other tests, so doesn't serve any use being called in a test on its own, as it has no assertions