### PR TITLE
SDK-468: Wrapper App changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ secrets.config
 [Oo]bj/
 [Bb]in/
 
-# Visual Studio 2015 cache/options directory
+# Visual Studio cache/options directory
 .vs/
 
 # PEM files in Examples
@@ -30,10 +30,6 @@ Backup*/
 **/packages/*
 # except build/, which is used as an MSBuild target.
 !**/packages/build/
-
-# SQL Server files
-*.mdf
-*.ldf
 
 # Coverage
 OpenCover/

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ if (user != null)
     Dictionary<string, Newtonsoft.Json.Linq.JToken> structuredPostalAddress = profile.StructuredPostalAddress.GetValue();
     string gender = profile.Gender.GetValue();
     string nationality = profile.Nationality.GetValue();
+    Yoti.Auth.Document.DocumentDetails documentDetails = profile.DocumentDetails.GetValue();
     bool isAgedOver18;
     AgeVerification over18Verification = profile.FindAgeOverVerification(18);
     if (over18Verification != null)

--- a/src/Yoti.Auth/Constants/ApplicationProfile.cs
+++ b/src/Yoti.Auth/Constants/ApplicationProfile.cs
@@ -1,6 +1,6 @@
 ﻿namespace Yoti.Auth.Constants
 {
-    internal static class ApplicationProfile
+    public static class ApplicationProfile
     {
         public const string ApplicationNameAttribute = "application_name";
         public const string ApplicationLogoAttribute = "application_logo";

--- a/src/Yoti.Auth/Web/HttpRequester.cs
+++ b/src/Yoti.Auth/Web/HttpRequester.cs
@@ -57,7 +57,9 @@ namespace Yoti.Auth.Web
                         else
                         {
                             throw new HttpRequestException(
-                                $"Unsuccessful response from request. Status Code: '{response.StatusCode}', Reason Phrase: '{response.ReasonPhrase}', Content: '{response.Content}'");
+                                $"Unsuccessful response from request. Status Code: '{response.StatusCode}', " +
+                                $"Reason Phrase: '{response.ReasonPhrase}', " +
+                                $"Content: '{response.Content}'");
                         }
                     }
                 }

--- a/src/Yoti.Auth/YotiClient.cs
+++ b/src/Yoti.Auth/YotiClient.cs
@@ -54,9 +54,9 @@ namespace Yoti.Auth
         /// </summary>
         /// <param name="encryptedToken">The encrypted returned by Yoti after successfully authenticating.</param>
         /// <returns>The account details of the logged in user as a <see cref="ActivityDetails"/>. </returns>
-        public ActivityDetails GetActivityDetails(string encryptedToken)
+        public ActivityDetails GetActivityDetails(string encryptedToken, Uri apiUrl = null)
         {
-            Task<ActivityDetails> task = Task.Run(async () => await GetActivityDetailsAsync(encryptedToken).ConfigureAwait(false));
+            Task<ActivityDetails> task = Task.Run(async () => await GetActivityDetailsAsync(encryptedToken, apiUrl).ConfigureAwait(false));
 
             return task.Result;
         }
@@ -66,9 +66,12 @@ namespace Yoti.Auth
         /// </summary>
         /// <param name="encryptedToken">The encrypted returned by Yoti after successfully authenticating.</param>
         /// <returns>The account details of the logged in user as a <see cref="ActivityDetails"/>. </returns>
-        public async Task<ActivityDetails> GetActivityDetailsAsync(string encryptedToken)
+        public async Task<ActivityDetails> GetActivityDetailsAsync(string encryptedToken, Uri apiUrl = null)
         {
-            return await _yotiClientEngine.GetActivityDetailsAsync(encryptedToken, _sdkId, _keyPair, _defaultApiUrl).ConfigureAwait(false);
+            if (apiUrl == null)
+                apiUrl = new Uri(_defaultApiUrl);
+
+            return await _yotiClientEngine.GetActivityDetailsAsync(encryptedToken, _sdkId, _keyPair, apiUrl).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/Yoti.Auth/YotiClientEngine.cs
+++ b/src/Yoti.Auth/YotiClientEngine.cs
@@ -43,15 +43,29 @@ namespace Yoti.Auth
 
             Dictionary<string, string> headers = HeadersFactory.Create(keyPair, httpMethod, endpoint, httpContent: null);
 
+            Uri requestUri = CreateRequestUri(apiUrl, endpoint);
+
             Response response = await _httpRequester.DoRequest(
                 _httpClient,
                 HttpMethod.Get,
-                new Uri(
-                    apiUrl + endpoint),
+                requestUri,
                 headers,
                 httpContent).ConfigureAwait(false);
 
             return ProfileParser.HandleResponse(keyPair, response);
+        }
+
+        private static Uri CreateRequestUri(Uri apiUrl, string endpoint)
+        {
+            string baseApiUrl = apiUrl.ToString();
+            if (baseApiUrl.EndsWith("/", StringComparison.OrdinalIgnoreCase))
+            {
+                return new Uri(baseApiUrl.TrimEnd('/') + endpoint);
+            }
+            else
+            {
+                return new Uri(baseApiUrl + endpoint);
+            }
         }
 
         public AmlResult PerformAmlCheck(string appId, AsymmetricCipherKeyPair keyPair, string apiUrl, IAmlProfile amlProfile)

--- a/src/Yoti.Auth/YotiClientEngine.cs
+++ b/src/Yoti.Auth/YotiClientEngine.cs
@@ -25,14 +25,14 @@ namespace Yoti.Auth
 #endif
         }
 
-        public ActivityDetails GetActivityDetails(string encryptedToken, string sdkId, AsymmetricCipherKeyPair keyPair, string apiUrl)
+        public ActivityDetails GetActivityDetails(string encryptedToken, string sdkId, AsymmetricCipherKeyPair keyPair, Uri apiUrl)
         {
             Task<ActivityDetails> task = Task.Run<ActivityDetails>(async () => await GetActivityDetailsAsync(encryptedToken, sdkId, keyPair, apiUrl).ConfigureAwait(false));
 
             return task.Result;
         }
 
-        public async Task<ActivityDetails> GetActivityDetailsAsync(string encryptedConnectToken, string sdkId, AsymmetricCipherKeyPair keyPair, string apiUrl)
+        public async Task<ActivityDetails> GetActivityDetailsAsync(string encryptedConnectToken, string sdkId, AsymmetricCipherKeyPair keyPair, Uri apiUrl)
         {
             string token = CryptoEngine.DecryptToken(encryptedConnectToken, keyPair);
             const string path = "profile";

--- a/src/Yoti.Auth/YotiClientEngine.cs
+++ b/src/Yoti.Auth/YotiClientEngine.cs
@@ -43,29 +43,14 @@ namespace Yoti.Auth
 
             Dictionary<string, string> headers = HeadersFactory.Create(keyPair, httpMethod, endpoint, httpContent: null);
 
-            Uri requestUri = CreateRequestUri(apiUrl, endpoint);
-
             Response response = await _httpRequester.DoRequest(
                 _httpClient,
                 HttpMethod.Get,
-                requestUri,
+                new Uri(apiUrl.ToString().TrimEnd('/') + endpoint),
                 headers,
                 httpContent).ConfigureAwait(false);
 
             return ProfileParser.HandleResponse(keyPair, response);
-        }
-
-        private static Uri CreateRequestUri(Uri apiUrl, string endpoint)
-        {
-            string baseApiUrl = apiUrl.ToString();
-            if (baseApiUrl.EndsWith("/", StringComparison.OrdinalIgnoreCase))
-            {
-                return new Uri(baseApiUrl.TrimEnd('/') + endpoint);
-            }
-            else
-            {
-                return new Uri(baseApiUrl + endpoint);
-            }
         }
 
         public AmlResult PerformAmlCheck(string appId, AsymmetricCipherKeyPair keyPair, string apiUrl, IAmlProfile amlProfile)

--- a/test/Yoti.Auth.Tests/TestData/TestAnchors.cs
+++ b/test/Yoti.Auth.Tests/TestData/TestAnchors.cs
@@ -2,7 +2,7 @@
 {
     internal static class TestAnchors
     {
-        public static readonly string DrivingLicenseAnchor =
+        public const string DrivingLicenseAnchor =
             "CjdBTkMtRE9Dz8qdV2DSwFJicqASUbdSRfmYOsJzswHQ4hDnfOUXtYeRlVOeQnVr3an"
             + "ESmMH7e2HEqAIMIIEHDCCAoSgAwIBAgIQIrSqBBTTXWxgGf6OvVm5XDANBgkqhkiG9w0"
             + "BAQsFADAuMSwwKgYDVQQDEyNkcml2aW5nLWxpY2VuY2UtcmVnaXN0cmF0aW9uLXNlcnZ"
@@ -43,7 +43,7 @@
             + "ASx2zgOkeIJVm5UnTC2ywMkcIARDR0uX8mLLaAhocZv/4kdenjmzEE1nkHW7ks7qh+II"
             + "J0YbSPwVkGiIc7BbgXGE8cSGwKuul83Yy/z1InbhBl2B1drEuOjoA";
 
-        public static readonly string PassportAnchor =
+        public const string PassportAnchor =
             "CjdBTkMtRE9D5oQ/YdIfjbvf1HL/HT7s/Xgse6TlNthXYyfF9knv02vq6Vxd5R"
             + "afiJbR9xVVl+knEowIMIIECDCCAnCgAwIBAgIRANEL6idR0hcevQr4tmIIcoowDQYJKo"
             + "ZIhvcNAQELBQAwJzElMCMGA1UEAxMccGFzc3BvcnQtcmVnaXN0cmF0aW9uLXNlcnZlcj"
@@ -84,7 +84,7 @@
             + "/2LTJHCAEQ0bvEyui02gIaHFIc8RKJ4U36MiJqXMjQlWXbhVu/URDuYOFXITEiHNs5Ua"
             + "Z0Q8FPlpgca5LurwwVkP/EqVsqzc1tuK06AA==";
 
-        public static readonly string YotiAdminAnchor =
+        public const string YotiAdminAnchor =
             "CjdBTkMtRE9DJrhhgGLoPILLZozIid4Aoiw/hLolQRF95pGqqsok3x"
             + "facAZQ9bJQD6JVzYPutOAIEpwIMIIEGDCCAoCgAwIBAgIRAMEOn91ajjMKgwOfw//2iI"
             + "0wDQYJKoZIhvcNAQELBQAwLjEsMCoGA1UEAxMjZHJpdmluZy1saWNlbmNlLXJlZ2lzdH"

--- a/test/Yoti.Auth.Tests/YotiClientEngineTests.cs
+++ b/test/Yoti.Auth.Tests/YotiClientEngineTests.cs
@@ -36,7 +36,7 @@ namespace Yoti.Auth.Tests
 
             var aggregateException = Assert.ThrowsException<AggregateException>(() =>
             {
-                engine.GetActivityDetails(EncryptedToken, SdkId, _keyPair, Constants.Web.DefaultYotiApiUrl);
+                engine.GetActivityDetails(EncryptedToken, SdkId, _keyPair, new Uri(Constants.Web.DefaultYotiApiUrl));
             });
 
             Assert.IsTrue(TestTools.Exceptions.IsExceptionInAggregateException<YotiProfileException>(aggregateException));
@@ -58,7 +58,7 @@ namespace Yoti.Auth.Tests
 
             var aggregateException = Assert.ThrowsException<AggregateException>(() =>
             {
-                engine.GetActivityDetails(EncryptedToken, SdkId, _keyPair, Constants.Web.DefaultYotiApiUrl);
+                engine.GetActivityDetails(EncryptedToken, SdkId, _keyPair, new Uri(Constants.Web.DefaultYotiApiUrl));
             });
 
             Assert.IsTrue(TestTools.Exceptions.IsExceptionInAggregateException<YotiProfileException>(aggregateException));
@@ -88,7 +88,7 @@ namespace Yoti.Auth.Tests
 
             var engine = new YotiClientEngine(httpRequester, new HttpClient());
 
-            ActivityDetails activityDetails = engine.GetActivityDetailsAsync(EncryptedToken, SdkId, _keyPair, Constants.Web.DefaultYotiApiUrl).Result;
+            ActivityDetails activityDetails = engine.GetActivityDetailsAsync(EncryptedToken, SdkId, _keyPair, new Uri(Constants.Web.DefaultYotiApiUrl)).Result;
 
             Assert.IsNotNull(activityDetails);
 
@@ -125,7 +125,7 @@ namespace Yoti.Auth.Tests
 
             var engine = new YotiClientEngine(httpRequester, new HttpClient());
 
-            ActivityDetails activityDetails = engine.GetActivityDetailsAsync(EncryptedToken, SdkId, _keyPair, Constants.Web.DefaultYotiApiUrl).Result;
+            ActivityDetails activityDetails = engine.GetActivityDetailsAsync(EncryptedToken, SdkId, _keyPair, new Uri(Constants.Web.DefaultYotiApiUrl)).Result;
 
             Assert.AreEqual(string.Empty, activityDetails.ParentRememberMeId);
         }
@@ -147,7 +147,7 @@ namespace Yoti.Auth.Tests
 
             var engine = new YotiClientEngine(httpRequester, new HttpClient());
 
-            ActivityDetails activityDetails = engine.GetActivityDetailsAsync(EncryptedToken, SdkId, _keyPair, Constants.Web.DefaultYotiApiUrl).Result;
+            ActivityDetails activityDetails = engine.GetActivityDetailsAsync(EncryptedToken, SdkId, _keyPair, new Uri(Constants.Web.DefaultYotiApiUrl)).Result;
 
             Assert.IsNotNull(activityDetails.Profile);
 


### PR DESCRIPTION
- Add DocumentDetails to README
- Make Yoti API configurable, for use with the wrapper application
- Creating URIs seem to sometimes result in a trailing slash, which caused a double slash when combined with the endpoint. I created `CreateRequestUri` to remove this trailing slash if it's present
- Made ApplicationProfile consts public (like UserProfile), so we can reference them externally