### PR TITLE
SDK-1094: Allow removal of authType, ensure uniqueness

### DIFF
--- a/src/Yoti.Auth/ShareUrl/Policy/DynamicPolicy.cs
+++ b/src/Yoti.Auth/ShareUrl/Policy/DynamicPolicy.cs
@@ -8,11 +8,14 @@ namespace Yoti.Auth.ShareUrl.Policy
     /// </summary>
     public class DynamicPolicy
     {
+        internal const int SelfieAuthType = 1;
+        internal const int PinAuthType = 2;
+
         [JsonProperty(PropertyName = "wanted")]
         private readonly ICollection<WantedAttribute> _wantedAttributes;
 
         [JsonProperty(PropertyName = "wanted_auth_types")]
-        private readonly List<int> _wantedAuthTypes;
+        private readonly HashSet<int> _wantedAuthTypes;
 
         [JsonProperty(PropertyName = "wanted_remember_me")]
         private readonly bool _wantedRememberMeId;
@@ -26,7 +29,7 @@ namespace Yoti.Auth.ShareUrl.Policy
 
         public DynamicPolicy(
             ICollection<WantedAttribute> wantedAttributes,
-            List<int> wantedAuthTypes,
+            HashSet<int> wantedAuthTypes,
             bool wantedRememberMeId)
         {
             _wantedAttributes = wantedAttributes;
@@ -51,7 +54,7 @@ namespace Yoti.Auth.ShareUrl.Policy
         /// Type of authentications
         /// </summary>
         [JsonIgnore]
-        public List<int> WantedAuthTypes
+        public HashSet<int> WantedAuthTypes
         {
             get
             {

--- a/src/Yoti.Auth/ShareUrl/Policy/DynamicPolicyBuilder.cs
+++ b/src/Yoti.Auth/ShareUrl/Policy/DynamicPolicyBuilder.cs
@@ -4,11 +4,8 @@ namespace Yoti.Auth.ShareUrl.Policy
 {
     public class DynamicPolicyBuilder
     {
-        private const int _selfieAuthType = 1;
-        private const int _pinAuthType = 2;
-
         private readonly Dictionary<string, WantedAttribute> _wantedAttributes = new Dictionary<string, WantedAttribute>();
-        private readonly List<int> _wantedAuthTypes = new List<int>();
+        private readonly HashSet<int> _wantedAuthTypes = new HashSet<int>();
         private bool _wantedRememberMeId;
 
         public DynamicPolicyBuilder WithWantedAttribute(WantedAttribute wantedAttribute)
@@ -111,8 +108,10 @@ namespace Yoti.Auth.ShareUrl.Policy
         {
             if (enabled)
             {
-                return WithAuthType(_selfieAuthType);
+                return WithAuthType(DynamicPolicy.SelfieAuthType);
             }
+
+            _wantedAuthTypes.Remove(DynamicPolicy.SelfieAuthType);
             return this;
         }
 
@@ -120,8 +119,10 @@ namespace Yoti.Auth.ShareUrl.Policy
         {
             if (enabled)
             {
-                return WithAuthType(_pinAuthType);
+                return WithAuthType(DynamicPolicy.PinAuthType);
             }
+
+            _wantedAuthTypes.Remove(DynamicPolicy.PinAuthType);
             return this;
         }
 

--- a/src/Yoti.Auth/ShareUrl/Policy/DynamicPolicyBuilder.cs
+++ b/src/Yoti.Auth/ShareUrl/Policy/DynamicPolicyBuilder.cs
@@ -106,29 +106,23 @@ namespace Yoti.Auth.ShareUrl.Policy
 
         public DynamicPolicyBuilder WithSelfieAuthentication(bool enabled)
         {
-            if (enabled)
-            {
-                return WithAuthType(DynamicPolicy.SelfieAuthType);
-            }
-
-            _wantedAuthTypes.Remove(DynamicPolicy.SelfieAuthType);
-            return this;
+            return WithAuthType(DynamicPolicy.SelfieAuthType, enabled);
         }
 
         public DynamicPolicyBuilder WithPinAuthentication(bool enabled)
         {
-            if (enabled)
-            {
-                return WithAuthType(DynamicPolicy.PinAuthType);
-            }
-
-            _wantedAuthTypes.Remove(DynamicPolicy.PinAuthType);
-            return this;
+            return WithAuthType(DynamicPolicy.PinAuthType, enabled);
         }
 
-        public DynamicPolicyBuilder WithAuthType(int authType)
+        public DynamicPolicyBuilder WithAuthType(int authType, bool enabled)
         {
-            _wantedAuthTypes.Add(authType);
+            if (enabled)
+            {
+                _wantedAuthTypes.Add(authType);
+                return this;
+            }
+
+            _wantedAuthTypes.Remove(authType);
             return this;
         }
 

--- a/test/Yoti.Auth.Tests/ShareUrl/Policy/DynamicPolicyBuilderTests.cs
+++ b/test/Yoti.Auth.Tests/ShareUrl/Policy/DynamicPolicyBuilderTests.cs
@@ -109,7 +109,7 @@ namespace Yoti.Auth.Tests.ShareUrl.Policy
             DynamicPolicy dynamicPolicy = new DynamicPolicyBuilder()
                 .WithSelfieAuthentication(enabled: true)
                 .WithPinAuthentication(enabled: true)
-                .WithAuthType(99)
+                .WithAuthType(authType: 99, enabled: true)
                 .Build();
 
             HashSet<int> result = dynamicPolicy.WantedAuthTypes;
@@ -129,6 +129,33 @@ namespace Yoti.Auth.Tests.ShareUrl.Policy
             HashSet<int> result = dynamicPolicy.WantedAuthTypes;
 
             Assert.AreEqual(0, result.Count);
+        }
+
+        [TestMethod]
+        public void BuildsWithAuthTypeEnabledThenDisabled()
+        {
+            DynamicPolicy dynamicPolicy = new DynamicPolicyBuilder()
+                .WithAuthType(24, enabled: true)
+                .WithAuthType(24, enabled: false)
+                .Build();
+
+            HashSet<int> result = dynamicPolicy.WantedAuthTypes;
+
+            Assert.AreEqual(0, result.Count);
+        }
+
+        [TestMethod]
+        public void BuildsWithAuthTypeDisabledThenEnabled()
+        {
+            DynamicPolicy dynamicPolicy = new DynamicPolicyBuilder()
+                .WithAuthType(23, enabled: false)
+                .WithAuthType(23, enabled: true)
+                .Build();
+
+            HashSet<int> result = dynamicPolicy.WantedAuthTypes;
+
+            Assert.AreEqual(1, result.Count);
+            Assert.IsTrue(result.SetEquals(new HashSet<int> { 23 }));
         }
 
         [TestMethod]
@@ -175,7 +202,7 @@ namespace Yoti.Auth.Tests.ShareUrl.Policy
         {
             DynamicPolicy dynamicPolicy = new DynamicPolicyBuilder()
                 .WithSelfieAuthentication(enabled: true)
-                .WithAuthType(DynamicPolicy.SelfieAuthType)
+                .WithAuthType(DynamicPolicy.SelfieAuthType, enabled: true)
                 .Build();
 
             HashSet<int> result = dynamicPolicy.WantedAuthTypes;
@@ -189,7 +216,7 @@ namespace Yoti.Auth.Tests.ShareUrl.Policy
         {
             DynamicPolicy dynamicPolicy = new DynamicPolicyBuilder()
                 .WithPinAuthentication(enabled: true)
-                .WithAuthType(DynamicPolicy.PinAuthType)
+                .WithAuthType(DynamicPolicy.PinAuthType, enabled: true)
                 .Build();
 
             HashSet<int> result = dynamicPolicy.WantedAuthTypes;

--- a/test/Yoti.Auth.Tests/ShareUrl/Policy/DynamicPolicyBuilderTests.cs
+++ b/test/Yoti.Auth.Tests/ShareUrl/Policy/DynamicPolicyBuilderTests.cs
@@ -8,6 +8,9 @@ namespace Yoti.Auth.Tests.ShareUrl.Policy
     [TestClass]
     public class DynamicPolicyBuilderTests
     {
+        private readonly int _expectedSelfieAuthValue = 1;
+        private readonly int _expectedPinAuthValue = 2;
+
         [TestMethod]
         public void EnsuresAnAttributeCanOnlyExistOnce()
         {
@@ -109,10 +112,10 @@ namespace Yoti.Auth.Tests.ShareUrl.Policy
                 .WithAuthType(99)
                 .Build();
 
-            List<int> result = dynamicPolicy.WantedAuthTypes;
+            HashSet<int> result = dynamicPolicy.WantedAuthTypes;
 
             Assert.AreEqual(3, result.Count);
-            CollectionAssert.AreEqual(result, new List<int> { 1, 2, 99 });
+            Assert.IsTrue(result.SetEquals(new HashSet<int> { _expectedSelfieAuthValue, _expectedPinAuthValue, 99 }));
         }
 
         [TestMethod]
@@ -123,7 +126,113 @@ namespace Yoti.Auth.Tests.ShareUrl.Policy
                 .WithPinAuthentication(enabled: false)
                 .Build();
 
-            List<int> result = dynamicPolicy.WantedAuthTypes;
+            HashSet<int> result = dynamicPolicy.WantedAuthTypes;
+
+            Assert.AreEqual(0, result.Count);
+        }
+
+        [TestMethod]
+        public void BuildsWithSelfieAuthenticationEnabledThenDisabled()
+        {
+            DynamicPolicy dynamicPolicy = new DynamicPolicyBuilder()
+                .WithSelfieAuthentication(enabled: true)
+                .WithSelfieAuthentication(enabled: false)
+                .Build();
+
+            HashSet<int> result = dynamicPolicy.WantedAuthTypes;
+
+            Assert.AreEqual(0, result.Count);
+        }
+
+        [TestMethod]
+        public void BuildsWithSelfieAuthenticationDisabledThenEnabled()
+        {
+            DynamicPolicy dynamicPolicy = new DynamicPolicyBuilder()
+                .WithSelfieAuthentication(enabled: false)
+                .WithSelfieAuthentication(enabled: true)
+                .Build();
+
+            HashSet<int> result = dynamicPolicy.WantedAuthTypes;
+
+            Assert.AreEqual(1, result.Count);
+            Assert.IsTrue(result.SetEquals(new HashSet<int> { _expectedSelfieAuthValue }));
+        }
+
+        [TestMethod]
+        public void BuildsWithSelfieAuthenticationDisabled()
+        {
+            DynamicPolicy dynamicPolicy = new DynamicPolicyBuilder()
+                .WithSelfieAuthentication(enabled: false)
+                .Build();
+
+            HashSet<int> result = dynamicPolicy.WantedAuthTypes;
+
+            Assert.AreEqual(0, result.Count);
+        }
+
+        [TestMethod]
+        public void FiltersSelfieAuthenticationDuplicates()
+        {
+            DynamicPolicy dynamicPolicy = new DynamicPolicyBuilder()
+                .WithSelfieAuthentication(enabled: true)
+                .WithAuthType(DynamicPolicy.SelfieAuthType)
+                .Build();
+
+            HashSet<int> result = dynamicPolicy.WantedAuthTypes;
+
+            Assert.AreEqual(1, result.Count);
+            Assert.IsTrue(result.SetEquals(new HashSet<int> { _expectedSelfieAuthValue }));
+        }
+
+        [TestMethod]
+        public void FiltersPinAuthenticationDuplicates()
+        {
+            DynamicPolicy dynamicPolicy = new DynamicPolicyBuilder()
+                .WithPinAuthentication(enabled: true)
+                .WithAuthType(DynamicPolicy.PinAuthType)
+                .Build();
+
+            HashSet<int> result = dynamicPolicy.WantedAuthTypes;
+
+            Assert.AreEqual(1, result.Count);
+            Assert.IsTrue(result.SetEquals(new HashSet<int> { _expectedPinAuthValue }));
+        }
+
+        [TestMethod]
+        public void BuildsWithPinAuthenticationEnabledThenDisabled()
+        {
+            DynamicPolicy dynamicPolicy = new DynamicPolicyBuilder()
+                .WithPinAuthentication(enabled: true)
+                .WithPinAuthentication(enabled: false)
+                .Build();
+
+            HashSet<int> result = dynamicPolicy.WantedAuthTypes;
+
+            Assert.AreEqual(0, result.Count);
+        }
+
+        [TestMethod]
+        public void BuildsWithPinAuthenticationDisabledThenEnabled()
+        {
+            DynamicPolicy dynamicPolicy = new DynamicPolicyBuilder()
+                .WithPinAuthentication(enabled: false)
+                .WithPinAuthentication(enabled: true)
+                .Build();
+
+            HashSet<int> result = dynamicPolicy.WantedAuthTypes;
+
+            Assert.AreEqual(1, result.Count);
+            Assert.IsTrue(result.SetEquals(new HashSet<int> { _expectedPinAuthValue }));
+        }
+
+        [TestMethod]
+        public void BuildsWithPinAuthenticationDisabled()
+        {
+            DynamicPolicy dynamicPolicy = new DynamicPolicyBuilder()
+                .WithPinAuthentication(enabled: false)
+                .Build();
+
+            HashSet<int> result = dynamicPolicy.WantedAuthTypes;
 
             Assert.AreEqual(0, result.Count);
         }

--- a/test/Yoti.Auth.Tests/YotiClientEngineTests.cs
+++ b/test/Yoti.Auth.Tests/YotiClientEngineTests.cs
@@ -8,7 +8,6 @@ using Org.BouncyCastle.Crypto;
 using Yoti.Auth.Aml;
 using Yoti.Auth.Exceptions;
 using Yoti.Auth.ShareUrl;
-using Yoti.Auth.Tests.TestTools;
 using Yoti.Auth.Tests.Common;
 using Yoti.Auth.Web;
 


### PR DESCRIPTION
- WithPinAuthentication(enabled:false) / WithSelfieAuthentication(enabled:false) now removes that AuthType from the Policy, and WithAuthType now has `enabled` field, allowing other auth types to be removed too
- Ensuring uniqueness for AuthTypes by using HashSet instead of a List