### PR TITLE
SDK-1205: Update Request Builder 

### DIFF
--- a/src/Yoti.Auth/Web/HeadersFactory.cs
+++ b/src/Yoti.Auth/Web/HeadersFactory.cs
@@ -8,16 +8,14 @@ namespace Yoti.Auth.Web
     {
         internal static HttpRequestMessage AddHeaders(HttpRequestMessage httpRequestMessage, AsymmetricCipherKeyPair keyPair, HttpMethod httpMethod, string endpoint, byte[] httpContent)
         {
-            string authKey = CryptoEngine.GetAuthKey(keyPair);
             string authDigest = SignedMessageFactory.SignMessage(httpMethod, endpoint, keyPair, httpContent);
             string SDKVersion = typeof(YotiClientEngine).GetTypeInfo().Assembly.GetName().Version.ToString();
 
-            return PutHeaders(httpRequestMessage, authDigest, authKey, SDKVersion);
+            return PutHeaders(httpRequestMessage, authDigest, SDKVersion);
         }
 
-        internal static HttpRequestMessage PutHeaders(HttpRequestMessage httpRequestMessage, string authDigest, string authKey, string SDKVersion)
+        internal static HttpRequestMessage PutHeaders(HttpRequestMessage httpRequestMessage, string authDigest, string SDKVersion)
         {
-            httpRequestMessage.Headers.Add(Constants.Web.AuthKeyHeader, authKey);
             httpRequestMessage.Headers.Add(Constants.Web.DigestHeader, authDigest);
             httpRequestMessage.Headers.Add(Constants.Web.YotiSdkHeader, Constants.Web.SdkIdentifier);
             httpRequestMessage.Headers.Add(Constants.Web.YotiSdkVersionHeader, $"{Constants.Web.SdkIdentifier}-{SDKVersion}");

--- a/src/Yoti.Auth/YotiClientEngine.cs
+++ b/src/Yoti.Auth/YotiClientEngine.cs
@@ -34,6 +34,7 @@ namespace Yoti.Auth
                 .WithBaseUri(apiUrl)
                 .WithEndpoint(path)
                 .WithQueryParam("appId", sdkId)
+                .WithHeader(Constants.Web.AuthKeyHeader, CryptoEngine.GetAuthKey(keyPair))
                 .Build();
 
             using (HttpResponseMessage response = await profileRequest.Execute(_httpClient).ConfigureAwait(false))

--- a/test/Yoti.Auth.Tests/GlobalSuppressions.cs
+++ b/test/Yoti.Auth.Tests/GlobalSuppressions.cs
@@ -1,0 +1,6 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S1481:Unused local variables should be removed", Justification = "Method needs to be called to check callback object in assertion below, even thought the result of this function is not used", Scope = "member", Target = "~M:Yoti.Auth.Tests.YotiClientEngineTests.ShouldAddAuthKeyHeaderToProfileRequest")]

--- a/test/Yoti.Auth.Tests/Web/HeadersFactoryTests.cs
+++ b/test/Yoti.Auth.Tests/Web/HeadersFactoryTests.cs
@@ -12,21 +12,17 @@ namespace Yoti.Auth.Tests.Web
     public class HeadersFactoryTests
     {
         private const string _someDigest = "someDigest";
-        private const string _someKey = "someKey";
 
         [TestMethod]
         public void ShouldCreateHeadersWithDigestAndKey()
         {
             string SDKVersionHeader = typeof(YotiClientEngine).GetTypeInfo().Assembly.GetName().Version.ToString();
 
-            HttpRequestMessage result = HeadersFactory.PutHeaders(new HttpRequestMessage(), _someDigest, _someKey, SDKVersionHeader);
+            HttpRequestMessage result = HeadersFactory.PutHeaders(new HttpRequestMessage(), _someDigest, SDKVersionHeader);
 
             Assert.AreEqual(
                 _someDigest,
                 result.Headers.GetValues(Constants.Web.DigestHeader).Single());
-            Assert.AreEqual(
-                _someKey,
-                result.Headers.GetValues(Constants.Web.AuthKeyHeader).Single());
             Assert.AreEqual(
                 Constants.Web.SdkIdentifier,
                 result.Headers.GetValues(Constants.Web.YotiSdkHeader).Single());


### PR DESCRIPTION
- Update Request Builder to not include Auth Key Header by default
- `.Callback` stores the parameters which the mockMessageHandler was called with, which we then inspect to check the header is present