### PR TITLE
SDK-914: FXCop Fixes, package updates

### DIFF
--- a/src/Examples/Aml/AmlExample/AmlExample.csproj
+++ b/src/Examples/Aml/AmlExample/AmlExample.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="DotNetEnv" Version="1.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="System.Json" Version="4.5.0" />
+    <PackageReference Include="System.Json" Version="4.6.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Examples/Aml/AmlExample/AmlExample.csproj
+++ b/src/Examples/Aml/AmlExample/AmlExample.csproj
@@ -5,6 +5,11 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="DotNetEnv" Version="1.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />

--- a/src/Examples/Profile/45Example/45Example.csproj
+++ b/src/Examples/Profile/45Example/45Example.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\..\packages\Microsoft.Net.Compilers.3.3.1\build\Microsoft.Net.Compilers.props" Condition="Exists('..\..\..\..\packages\Microsoft.Net.Compilers.3.3.1\build\Microsoft.Net.Compilers.props')" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.Default.props" Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.Default.props')" />
-  <Import Project="..\..\..\..\packages\Microsoft.Net.Compilers.3.0.0\build\Microsoft.Net.Compilers.props" Condition="Exists('..\..\..\..\packages\Microsoft.Net.Compilers.3.0.0\build\Microsoft.Net.Compilers.props')" />
   <Import Project="..\..\..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props" Condition="Exists('..\..\..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -72,7 +72,7 @@
       <HintPath>Bin\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\NLog.4.6.3\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\..\..\..\packages\NLog.4.6.7\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
@@ -217,7 +217,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\..\..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\Microsoft.Net.Compilers.3.0.0\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.Net.Compilers.3.0.0\build\Microsoft.Net.Compilers.props'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\Microsoft.Net.Compilers.3.3.1\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.Net.Compilers.3.3.1\build\Microsoft.Net.Compilers.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Examples/Profile/45Example/45Example.csproj
+++ b/src/Examples/Profile/45Example/45Example.csproj
@@ -38,6 +38,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -121,6 +122,7 @@
     <Compile Include="Global.asax.cs">
       <DependentUpon>Global.asax</DependentUpon>
     </Compile>
+    <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Models\DisplayAttribute.cs" />
     <Compile Include="Models\DisplayAttributes.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Examples/Profile/45Example/GlobalSuppressions.cs
+++ b/src/Examples/Profile/45Example/GlobalSuppressions.cs
@@ -1,0 +1,6 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "Auto-generated", Scope = "member", Target = "~M:Example.MvcApplication.Application_Start")]

--- a/src/Examples/Profile/45Example/packages.config
+++ b/src/Examples/Profile/45Example/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Antlr" version="3.5.0.2" targetFramework="net451" />
   <package id="bootstrap" version="4.3.1" targetFramework="net451" />
-  <package id="Google.Protobuf" version="3.7.0" targetFramework="net451" />
+  <package id="Google.Protobuf" version="3.10.0" targetFramework="net452" />
   <package id="jQuery" version="3.4.1" targetFramework="net451" />
   <package id="jQuery.Validation" version="1.17.0" targetFramework="net451" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.7" targetFramework="net451" />
@@ -11,7 +11,7 @@
   <package id="Microsoft.AspNet.WebPages" version="3.2.7" targetFramework="net451" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.1" targetFramework="net451" />
   <package id="Microsoft.jQuery.Unobtrusive.Validation" version="3.2.11" targetFramework="net451" />
-  <package id="Microsoft.Net.Compilers" version="3.0.0" targetFramework="net451" developmentDependency="true" />
+  <package id="Microsoft.Net.Compilers" version="3.3.1" targetFramework="net452" developmentDependency="true" />
   <package id="Microsoft.Owin" version="4.0.1" targetFramework="net451" />
   <package id="Microsoft.Owin.Host.SystemWeb" version="4.0.1" targetFramework="net451" />
   <package id="Microsoft.Owin.Security" version="4.0.1" targetFramework="net451" />
@@ -19,7 +19,7 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net452" />
   <package id="Modernizr" version="2.8.3" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net451" />
-  <package id="NLog" version="4.6.3" targetFramework="net451" />
+  <package id="NLog" version="4.6.7" targetFramework="net452" />
   <package id="Owin" version="1.0" targetFramework="net451" />
   <package id="popper.js" version="1.14.3" targetFramework="net451" />
   <package id="Portable.BouncyCastle" version="1.8.5" targetFramework="net451" />

--- a/src/Examples/Profile/CoreExample/CoreExample.csproj
+++ b/src/Examples/Profile/CoreExample/CoreExample.csproj
@@ -7,6 +7,11 @@
     <DockerComposeProjectPath>..\..\docker-compose.dcproj</DockerComposeProjectPath>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="DotNetEnv" Version="1.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.All" />

--- a/src/Examples/Profile/CoreExample/CoreExample.csproj
+++ b/src/Examples/Profile/CoreExample/CoreExample.csproj
@@ -12,13 +12,13 @@
     <PackageReference Include="Microsoft.AspNetCore.All" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.1.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.0.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.0.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.9" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.3.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.7.8" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Examples/Profile/CoreExample/GlobalSuppressions.cs
+++ b/src/Examples/Profile/CoreExample/GlobalSuppressions.cs
@@ -1,0 +1,7 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "Auto-generated", Scope = "member", Target = "~M:CoreExample.Startup.ConfigureServices(Microsoft.Extensions.DependencyInjection.IServiceCollection)")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "Auto-generated", Scope = "member", Target = "~M:CoreExample.Startup.Configure(Microsoft.AspNetCore.Builder.IApplicationBuilder,Microsoft.AspNetCore.Hosting.IHostingEnvironment)")]

--- a/src/Yoti.Auth.Sandbox/Yoti.Auth.Sandbox.csproj
+++ b/src/Yoti.Auth.Sandbox/Yoti.Auth.Sandbox.csproj
@@ -5,6 +5,11 @@
     <NeutralLanguage>en</NeutralLanguage>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.3" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />

--- a/src/Yoti.Auth.Sandbox/YotiSandboxClient.cs
+++ b/src/Yoti.Auth.Sandbox/YotiSandboxClient.cs
@@ -12,7 +12,7 @@ namespace Yoti.Auth.Sandbox
     public class YotiSandboxClient
     {
         private const string _yotiSandboxPathPrefix = "/sandbox/v1";
-        private readonly Uri _defaultSandboxApiUrl = new Uri(Constants.Web.DefaultYotiHost + _yotiSandboxPathPrefix);
+        private readonly Uri _defaultSandboxApiUrl = new Uri(Constants.Api.DefaultYotiHost + _yotiSandboxPathPrefix);
         private readonly HttpClient _httpClient;
         private readonly Uri _apiUri;
         private readonly string _appId;

--- a/src/Yoti.Auth/Constants/Web.cs
+++ b/src/Yoti.Auth/Constants/Web.cs
@@ -1,6 +1,6 @@
 ﻿namespace Yoti.Auth.Constants
 {
-    public static class Web
+    public static class Api
     {
         public const string DefaultYotiHost = @"https://api.yoti.com";
         public const string YotiApiPathPrefix = "api/v1";

--- a/src/Yoti.Auth/Web/HeadersFactory.cs
+++ b/src/Yoti.Auth/Web/HeadersFactory.cs
@@ -16,9 +16,9 @@ namespace Yoti.Auth.Web
 
         internal static HttpRequestMessage PutHeaders(HttpRequestMessage httpRequestMessage, string authDigest, string SDKVersion)
         {
-            httpRequestMessage.Headers.Add(Constants.Web.DigestHeader, authDigest);
-            httpRequestMessage.Headers.Add(Constants.Web.YotiSdkHeader, Constants.Web.SdkIdentifier);
-            httpRequestMessage.Headers.Add(Constants.Web.YotiSdkVersionHeader, $"{Constants.Web.SdkIdentifier}-{SDKVersion}");
+            httpRequestMessage.Headers.Add(Constants.Api.DigestHeader, authDigest);
+            httpRequestMessage.Headers.Add(Constants.Api.YotiSdkHeader, Constants.Api.SdkIdentifier);
+            httpRequestMessage.Headers.Add(Constants.Api.YotiSdkVersionHeader, $"{Constants.Api.SdkIdentifier}-{SDKVersion}");
 
             return httpRequestMessage;
         }

--- a/src/Yoti.Auth/Yoti.Auth.csproj
+++ b/src/Yoti.Auth/Yoti.Auth.csproj
@@ -23,13 +23,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.7.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.3">
+    <PackageReference Include="Google.Protobuf" Version="3.10.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="NLog" Version="4.6.3" />
+    <PackageReference Include="NLog" Version="4.6.7" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.5" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>

--- a/src/Yoti.Auth/Yoti.Auth.csproj
+++ b/src/Yoti.Auth/Yoti.Auth.csproj
@@ -22,6 +22,11 @@
     <Version>3.0.0</Version>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard1.6|AnyCPU'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.10.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.5">

--- a/src/Yoti.Auth/YotiClient.cs
+++ b/src/Yoti.Auth/YotiClient.cs
@@ -13,7 +13,7 @@ namespace Yoti.Auth
         private readonly string _sdkId;
         private readonly AsymmetricCipherKeyPair _keyPair;
         private readonly YotiClientEngine _yotiClientEngine;
-        private Uri _apiUri = new Uri(Constants.Web.DefaultYotiApiUrl);
+        private readonly Uri _defaultApiUrl = new Uri(Constants.Api.DefaultYotiApiUrl);
 
         /// <summary>
         /// Create a <see cref="YotiClient"/>

--- a/src/Yoti.Auth/YotiClient.cs
+++ b/src/Yoti.Auth/YotiClient.cs
@@ -13,7 +13,7 @@ namespace Yoti.Auth
         private readonly string _sdkId;
         private readonly AsymmetricCipherKeyPair _keyPair;
         private readonly YotiClientEngine _yotiClientEngine;
-        private readonly Uri _defaultApiUrl = new Uri(Constants.Api.DefaultYotiApiUrl);
+        private Uri _apiUri = new Uri(Constants.Api.DefaultYotiApiUrl);
 
         /// <summary>
         /// Create a <see cref="YotiClient"/>

--- a/src/Yoti.Auth/YotiClientEngine.cs
+++ b/src/Yoti.Auth/YotiClientEngine.cs
@@ -34,7 +34,7 @@ namespace Yoti.Auth
                 .WithBaseUri(apiUrl)
                 .WithEndpoint(path)
                 .WithQueryParam("appId", sdkId)
-                .WithHeader(Constants.Web.AuthKeyHeader, CryptoEngine.GetAuthKey(keyPair))
+                .WithHeader(Constants.Api.AuthKeyHeader, CryptoEngine.GetAuthKey(keyPair))
                 .Build();
 
             using (HttpResponseMessage response = await profileRequest.Execute(_httpClient).ConfigureAwait(false))

--- a/test/Yoti.Auth.Sandbox.Tests/Yoti.Auth.Sandbox.Tests.csproj
+++ b/test/Yoti.Auth.Sandbox.Tests/Yoti.Auth.Sandbox.Tests.csproj
@@ -6,6 +6,11 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />

--- a/test/Yoti.Auth.Sandbox.Tests/Yoti.Auth.Sandbox.Tests.csproj
+++ b/test/Yoti.Auth.Sandbox.Tests/Yoti.Auth.Sandbox.Tests.csproj
@@ -11,7 +11,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Moq" Version="4.12.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="NLog" Version="4.6.6" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>

--- a/test/Yoti.Auth.Tests.Common/Yoti.Auth.Tests.Common.csproj
+++ b/test/Yoti.Auth.Tests.Common/Yoti.Auth.Tests.Common.csproj
@@ -4,6 +4,11 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Yoti.Auth\Yoti.Auth.csproj" />
   </ItemGroup>

--- a/test/Yoti.Auth.Tests/Web/HeadersFactoryTests.cs
+++ b/test/Yoti.Auth.Tests/Web/HeadersFactoryTests.cs
@@ -22,13 +22,13 @@ namespace Yoti.Auth.Tests.Web
 
             Assert.AreEqual(
                 _someDigest,
-                result.Headers.GetValues(Constants.Web.DigestHeader).Single());
+                result.Headers.GetValues(Constants.Api.DigestHeader).Single());
             Assert.AreEqual(
-                Constants.Web.SdkIdentifier,
-                result.Headers.GetValues(Constants.Web.YotiSdkHeader).Single());
+                Constants.Api.SdkIdentifier,
+                result.Headers.GetValues(Constants.Api.YotiSdkHeader).Single());
             Assert.AreEqual(
-                $"{Constants.Web.SdkIdentifier}-{SDKVersionHeader}",
-                result.Headers.GetValues(Constants.Web.YotiSdkVersionHeader).Single());
+                $"{Constants.Api.SdkIdentifier}-{SDKVersionHeader}",
+                result.Headers.GetValues(Constants.Api.YotiSdkVersionHeader).Single());
         }
     }
 }

--- a/test/Yoti.Auth.Tests/Web/RequestBuilderTests.cs
+++ b/test/Yoti.Auth.Tests/Web/RequestBuilderTests.cs
@@ -195,7 +195,7 @@ namespace Yoti.Auth.Tests.Web
 
             Request profileRequest = new RequestBuilder()
                 .WithKeyPair(KeyPair.Get())
-                .WithBaseUri(new Uri(Constants.Web.DefaultYotiApiUrl))
+                .WithBaseUri(new Uri(Constants.Api.DefaultYotiApiUrl))
                 .WithEndpoint($"/profile/{token}")
                 .WithHttpMethod(HttpMethod.Get)
                 .WithQueryParam("appId", _sdkId)
@@ -211,7 +211,7 @@ namespace Yoti.Auth.Tests.Web
         {
             Request amlRequest = new RequestBuilder()
                 .WithKeyPair(KeyPair.Get())
-                .WithBaseUri(new Uri(Constants.Web.DefaultYotiApiUrl))
+                .WithBaseUri(new Uri(Constants.Api.DefaultYotiApiUrl))
                 .WithEndpoint("/aml-check")
                 .WithHttpMethod(HttpMethod.Post)
                 .WithQueryParam("appId", _sdkId)

--- a/test/Yoti.Auth.Tests/Yoti.Auth.Tests.csproj
+++ b/test/Yoti.Auth.Tests/Yoti.Auth.Tests.csproj
@@ -14,6 +14,11 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\test\Yoti.Auth.Tests.Common\Yoti.Auth.Tests.Common.csproj" />
     <ProjectReference Include="..\..\src\Yoti.Auth\Yoti.Auth.csproj" />

--- a/test/Yoti.Auth.Tests/Yoti.Auth.Tests.csproj
+++ b/test/Yoti.Auth.Tests/Yoti.Auth.Tests.csproj
@@ -20,13 +20,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
-    <PackageReference Include="Moq" Version="4.10.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Moq" Version="4.13.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
     <PackageReference Include="OpenCover" Version="4.7.922" />
-    <PackageReference Include="ReportGenerator" Version="4.1.5" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1" />
+    <PackageReference Include="ReportGenerator" Version="4.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Yoti.Auth.Tests/Yoti.Auth.Tests.csproj
+++ b/test/Yoti.Auth.Tests/Yoti.Auth.Tests.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
     <PackageReference Include="OpenCover" Version="4.7.922" />
     <PackageReference Include="ReportGenerator" Version="4.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Yoti.Auth.Tests/YotiClientEngineTests.cs
+++ b/test/Yoti.Auth.Tests/YotiClientEngineTests.cs
@@ -102,9 +102,9 @@ namespace Yoti.Auth.Tests
 
             var engine = new YotiClientEngine(new HttpClient(handlerMock.Object));
 
-            ActivityDetails _ = engine.GetActivityDetailsAsync(EncryptedToken, SdkId, _keyPair, new Uri(Constants.Web.DefaultYotiApiUrl)).Result;
+            ActivityDetails _ = engine.GetActivityDetailsAsync(EncryptedToken, SdkId, _keyPair, new Uri(Constants.Api.DefaultYotiApiUrl)).Result;
 
-            Assert.IsTrue(_httpRequestMessage.Headers.Contains(Constants.Web.AuthKeyHeader));
+            Assert.IsTrue(_httpRequestMessage.Headers.Contains(Constants.Api.AuthKeyHeader));
         }
 
         [TestMethod]

--- a/test/Yoti.Auth.Tests/YotiClientEngineTests.cs
+++ b/test/Yoti.Auth.Tests/YotiClientEngineTests.cs
@@ -34,7 +34,7 @@ namespace Yoti.Auth.Tests
 
             var profileException = Assert.ThrowsExceptionAsync<YotiProfileException>(async () =>
             {
-                await engine.GetActivityDetailsAsync(EncryptedToken, SdkId, _keyPair, new Uri(Constants.Web.DefaultYotiApiUrl));
+                await engine.GetActivityDetailsAsync(EncryptedToken, SdkId, _keyPair, new Uri(Constants.Api.DefaultYotiApiUrl));
             }).Result;
 
             Assert.IsTrue(profileException.Message.StartsWith("The share was not successful"));
@@ -51,7 +51,7 @@ namespace Yoti.Auth.Tests
 
             var profileException = Assert.ThrowsExceptionAsync<YotiProfileException>(async () =>
             {
-                await engine.GetActivityDetailsAsync(EncryptedToken, SdkId, _keyPair, new Uri(Constants.Web.DefaultYotiApiUrl));
+                await engine.GetActivityDetailsAsync(EncryptedToken, SdkId, _keyPair, new Uri(Constants.Api.DefaultYotiApiUrl));
             }).Result;
 
             Assert.IsTrue(profileException.Message.StartsWith("The receipt of the parsed response is null"));
@@ -72,7 +72,7 @@ namespace Yoti.Auth.Tests
 
             var engine = new YotiClientEngine(new HttpClient(handlerMock.Object));
 
-            ActivityDetails activityDetails = engine.GetActivityDetailsAsync(EncryptedToken, SdkId, _keyPair, new Uri(Constants.Web.DefaultYotiApiUrl)).Result;
+            ActivityDetails activityDetails = engine.GetActivityDetailsAsync(EncryptedToken, SdkId, _keyPair, new Uri(Constants.Api.DefaultYotiApiUrl)).Result;
 
             Assert.IsNotNull(activityDetails);
 
@@ -119,7 +119,7 @@ namespace Yoti.Auth.Tests
 
             var engine = new YotiClientEngine(new HttpClient(handlerMock.Object));
 
-            ActivityDetails activityDetails = engine.GetActivityDetailsAsync(EncryptedToken, SdkId, _keyPair, new Uri(Constants.Web.DefaultYotiApiUrl)).Result;
+            ActivityDetails activityDetails = engine.GetActivityDetailsAsync(EncryptedToken, SdkId, _keyPair, new Uri(Constants.Api.DefaultYotiApiUrl)).Result;
 
             Assert.AreEqual(string.Empty, activityDetails.ParentRememberMeId);
         }
@@ -135,7 +135,7 @@ namespace Yoti.Auth.Tests
 
             var engine = new YotiClientEngine(new HttpClient(handlerMock.Object));
 
-            ActivityDetails activityDetails = engine.GetActivityDetailsAsync(EncryptedToken, SdkId, _keyPair, new Uri(Constants.Web.DefaultYotiApiUrl)).Result;
+            ActivityDetails activityDetails = engine.GetActivityDetailsAsync(EncryptedToken, SdkId, _keyPair, new Uri(Constants.Api.DefaultYotiApiUrl)).Result;
 
             Assert.IsNotNull(activityDetails.Profile);
 
@@ -157,7 +157,7 @@ namespace Yoti.Auth.Tests
 
             AmlResult amlResult = await engine.PerformAmlCheckAsync(
                 SdkId, _keyPair,
-                new Uri(Constants.Web.DefaultYotiApiUrl),
+                new Uri(Constants.Api.DefaultYotiApiUrl),
                 amlProfile);
 
             Assert.IsNotNull(amlResult);
@@ -185,7 +185,7 @@ namespace Yoti.Auth.Tests
 
             Assert.ThrowsExceptionAsync<AmlException>(async () =>
             {
-                await engine.PerformAmlCheckAsync(SdkId, _keyPair, new Uri(Constants.Web.DefaultYotiApiUrl), amlProfile);
+                await engine.PerformAmlCheckAsync(SdkId, _keyPair, new Uri(Constants.Api.DefaultYotiApiUrl), amlProfile);
             });
         }
 
@@ -202,7 +202,7 @@ namespace Yoti.Auth.Tests
             var engine = new YotiClientEngine(new HttpClient(handlerMock.Object));
             DynamicScenario dynamicScenario = TestTools.ShareUrl.CreateStandardDynamicScenario();
 
-            ShareUrlResult shareUrlResult = await engine.CreateShareURLAsync(SdkId, _keyPair, new Uri(Constants.Web.DefaultYotiApiUrl), dynamicScenario);
+            ShareUrlResult shareUrlResult = await engine.CreateShareURLAsync(SdkId, _keyPair, new Uri(Constants.Api.DefaultYotiApiUrl), dynamicScenario);
 
             Assert.IsNotNull(shareUrlResult);
             Assert.AreEqual(new Uri(shareUrl), shareUrlResult.Url);
@@ -228,7 +228,7 @@ namespace Yoti.Auth.Tests
 
             var aggregateException = Assert.ThrowsException<AggregateException>(() =>
             {
-                engine.CreateShareURLAsync(SdkId, _keyPair, new Uri(Constants.Web.DefaultYotiApiUrl), dynamicScenario).Wait();
+                engine.CreateShareURLAsync(SdkId, _keyPair, new Uri(Constants.Api.DefaultYotiApiUrl), dynamicScenario).Wait();
             });
 
             Assert.IsTrue(TestTools.Exceptions.IsExceptionInAggregateException<DynamicShareException>(aggregateException));


### PR DESCRIPTION
- Have reverted to specifying a version in Yoti.Auth.Tests for Microsoft.AspNetCore.All after MS changed their advice - https://github.com/aspnet/AspNetCore.Docs/issues/6430#issuecomment-403296211
- Add "Treat Warnings As Errors"
- Rename (Constants.)"Web" to "Api" to avoid namespace conflict