### PR TITLE
SDK-1225: Target frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,13 @@ Please feel free to reach out
 
 ## Supported Frameworks
 - .NET Standard 1.6
+- .NET Standard 2.0
+- .NET Core App 1.1
+- .NET Core App 2.1
 - .NET 4.5
 - .NET 4.6
+- .NET 4.7
+- .NET 4.8
 
 ## An Architectural View
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Please feel free to reach out
 - .NET Standard 1.6
 - .NET Standard 2.0
 - .NET Core App 1.1
+- .NET Core App 2.0
 - .NET Core App 2.1
 - .NET 4.5
 - .NET 4.6

--- a/src/Yoti.Auth/Anchors/AnchorCertificateParser.cs
+++ b/src/Yoti.Auth/Anchors/AnchorCertificateParser.cs
@@ -23,7 +23,7 @@ namespace Yoti.Auth.Anchors
                 X509Certificate2 certificate = new X509Certificate2(byteString.ToByteArray());
 
                 // certificate is only disposable in .NET 4.6+
-#if NETSTANDARD1_6 || NET46 || NET461
+#if !NET45
                 using (certificate)
                 {
 #endif
@@ -46,7 +46,7 @@ namespace Yoti.Auth.Anchors
 
                         extensions = GetListOfStringsFromExtension(certificate, extensionOid);
                     }
-#if NETSTANDARD1_6 || NET46 || NET461
+#if !NET45
                 }
 #endif
                 if (extensions.Count == 0)

--- a/src/Yoti.Auth/Conversion.cs
+++ b/src/Yoti.Auth/Conversion.cs
@@ -31,8 +31,11 @@ namespace Yoti.Auth
         /// </summary>
         public static byte[] UrlSafeBase64ToBytes(string urlSafeBase64)
         {
+#if NETCOREAPP2_2
+            string base64 = urlSafeBase64.Replace("-", "+", StringComparison.Ordinal).Replace("_", "/", StringComparison.Ordinal);
+#else
             string base64 = urlSafeBase64.Replace("-", "+").Replace("_", "/");
-
+#endif
             return Base64ToBytes(base64);
         }
     }

--- a/src/Yoti.Auth/Conversion.cs
+++ b/src/Yoti.Auth/Conversion.cs
@@ -31,7 +31,7 @@ namespace Yoti.Auth
         /// </summary>
         public static byte[] UrlSafeBase64ToBytes(string urlSafeBase64)
         {
-#if NETCOREAPP2_2
+#if NETCOREAPP2_1 || NETCOREAPP2_0
             string base64 = urlSafeBase64.Replace("-", "+", StringComparison.Ordinal).Replace("_", "/", StringComparison.Ordinal);
 #else
             string base64 = urlSafeBase64.Replace("-", "+").Replace("_", "/");

--- a/src/Yoti.Auth/Yoti.Auth.csproj
+++ b/src/Yoti.Auth/Yoti.Auth.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;net45;net451;net452;net46;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.6;netcoreapp2.1;netcoreapp1.1;net48;net47;net46;net45</TargetFrameworks>
     <AssemblyName>Yoti.Auth</AssemblyName>
     <PackageId>Yoti</PackageId>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>

--- a/src/Yoti.Auth/Yoti.Auth.csproj
+++ b/src/Yoti.Auth/Yoti.Auth.csproj
@@ -18,7 +18,7 @@
     <PackageTags>yoti 2FA multifactor authentication verification identity login register verify 2Factor sdk</PackageTags>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <LangVersion>latest</LangVersion>
-    <Version>3.0.0</Version>
+    <Version>3.1.0</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Yoti.Auth/Yoti.Auth.csproj
+++ b/src/Yoti.Auth/Yoti.Auth.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard1.6;netcoreapp2.1;netcoreapp1.1;net48;net47;net46;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.6;netcoreapp2.1;netcoreapp2.0;netcoreapp1.1;net48;net47;net46;net45</TargetFrameworks>
     <AssemblyName>Yoti.Auth</AssemblyName>
     <PackageId>Yoti</PackageId>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>

--- a/src/Yoti.Auth/YotiClientEngine.cs
+++ b/src/Yoti.Auth/YotiClientEngine.cs
@@ -18,7 +18,7 @@ namespace Yoti.Auth
         {
             _httpClient = httpClient;
 
-#if !NETSTANDARD1_6
+#if !NETSTANDARD1_6 && !NETCOREAPP1_1
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 #endif
         }


### PR DESCRIPTION
- Will wait for SDK v3.0.0 release before merging
- .NET Core 3.0 requires MS Build Tools 16 to compile, which is only included in Visual Studio 2019. I've chosen to not include this for now, as it will restrict who can compile the SDK (both internally and externally)
- Additionally Travis doesn't support .NET Core App 2.2 yet unfortunately, so I've only added 2.1