### PR TITLE
SDK-1364: Allow all RFC3339 dates for Expiry Date

### DIFF
--- a/src/Yoti.Auth/Constants/Format.cs
+++ b/src/Yoti.Auth/Constants/Format.cs
@@ -2,6 +2,6 @@
 {
     internal static class Format
     {
-        public const string RFC3339PatternMilli = "yyyy-MM-dd'T'HH:mm:ss.fffzzz";
+        public const string RFC3339PatternMilli = "yyyy-MM-dd'T'HH:mm:ss.ffffffZ";
     }
 }

--- a/src/Yoti.Auth/Share/ThirdParty/ThirdPartyAttributeConverter.cs
+++ b/src/Yoti.Auth/Share/ThirdParty/ThirdPartyAttributeConverter.cs
@@ -58,14 +58,13 @@ namespace Yoti.Auth.Share.ThirdParty
             if (string.IsNullOrEmpty(dateTimeStringValue))
                 return null;
 
-            if (DateTime.TryParseExact(
+            if (DateTime.TryParse(
                  dateTimeStringValue,
-                 format: Constants.Format.RFC3339PatternMilli,
                  provider: CultureInfo.InvariantCulture,
-                 style: DateTimeStyles.None,
+                 styles: DateTimeStyles.None,
                  result: out DateTime date))
             {
-                return date;
+                return date.ToUniversalTime();
             }
             else
                 logger.Warn($"Failed to parse date: {dateTimeStringValue}");

--- a/test/Yoti.Auth.Tests/Anchors/AnchorTests.cs
+++ b/test/Yoti.Auth.Tests/Anchors/AnchorTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
+using Google.Protobuf.Collections;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json.Linq;
 using Yoti.Auth.Anchors;
@@ -9,7 +10,7 @@ using Yoti.Auth.Images;
 using Yoti.Auth.Profile;
 using Yoti.Auth.Tests.TestData;
 
-namespace Yoti.Auth.Tests
+namespace Yoti.Auth.Tests.Anchors
 {
     [TestClass]
     public class AnchorTests

--- a/test/Yoti.Auth.Tests/Anchors/SignedTimestampTests.cs
+++ b/test/Yoti.Auth.Tests/Anchors/SignedTimestampTests.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Yoti.Auth.Anchors;
+using Yoti.Auth.Constants;
+
+namespace Yoti.Auth.Tests.Anchors
+{
+    [TestClass]
+    public class SignedTimestampTests
+    {
+        [TestMethod]
+        public void ShouldHandleNegativeTimestamp()
+        {
+            var signedUnixTimestamp = -1571630945999999;
+            var unsignedUnixTimestamp = (ulong)signedUnixTimestamp;
+            var protoBufSignedTimestamp = new ProtoBuf.Common.SignedTimestamp { Timestamp = unsignedUnixTimestamp };
+
+            var signedTimestamp = new SignedTimestamp(protoBufSignedTimestamp);
+            string result = signedTimestamp.GetTimestamp().ToString(Format.RFC3339PatternMilli, DateTimeFormatInfo.InvariantInfo);
+
+            Assert.AreEqual("1920-03-13T19:50:54.000001Z", result);
+        }
+    }
+}

--- a/test/Yoti.Auth.Tests/Share/ExtraDataConverterTests.cs
+++ b/test/Yoti.Auth.Tests/Share/ExtraDataConverterTests.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using System;
+using System.Globalization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Yoti.Auth.Share;
 
 namespace Yoti.Auth.Tests.Share
@@ -14,7 +16,12 @@ namespace Yoti.Auth.Tests.Share
 
             ExtraData result = ExtraDataConverter.ParseExtraDataProto(extraDataBytes);
 
-            Assert.IsNull(result.AttributeIssuanceDetails.ExpiryDate);
+            string expectedDateTime = "2019-10-15T22:04:05.123000";
+            DateTime nonNullableExpiryDate = (DateTime)result.AttributeIssuanceDetails.ExpiryDate;
+
+            string actualDateTime = nonNullableExpiryDate.ToString("yyyy-MM-dd'T'HH:mm:ss.ffffff", DateTimeFormatInfo.InvariantInfo);
+
+            Assert.AreEqual(expectedDateTime, actualDateTime);
             Assert.AreEqual("c29tZUlzc3VhbmNlVG9rZW4=", result.AttributeIssuanceDetails.Token);
             Assert.AreEqual(2, result.AttributeIssuanceDetails.IssuingAttributes.Count);
             Assert.AreEqual("com.thirdparty.id", result.AttributeIssuanceDetails.IssuingAttributes[0].Name);

--- a/test/Yoti.Auth.Tests/Share/ThirdParty/ThirdPartyAttributeConverterTests.cs
+++ b/test/Yoti.Auth.Tests/Share/ThirdParty/ThirdPartyAttributeConverterTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Globalization;
 using Google.Protobuf;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Yoti.Auth.Constants;
 using Yoti.Auth.Exceptions;
 using Yoti.Auth.Share.ThirdParty;
 
@@ -20,13 +22,39 @@ namespace Yoti.Auth.Tests.Share.ThirdParty
             Assert.IsNull(result.ExpiryDate);
         }
 
-        [TestMethod]
-        public void ShouldParseDate()
+        [DataTestMethod]
+        [DataRow("2019-01-02T03:04:05.678Z")]
+        [DataRow("2019-01-02T04:04:05.678+01:00")]
+        [DataRow("2019-01-02T15:04:05.678+12:00")]
+        [DataRow("2019-01-02T02:04:05.678-01:00")]
+        [DataRow("2019-01-01T15:04:05.678-12:00")]
+        public void ShouldParseDifferentTimezonesDate(string expiryDate)
         {
-            byte[] byteValue = CreateSerializedThirdPartyAttribute("token", _someExpiryDate);
+            byte[] byteValue = CreateSerializedThirdPartyAttribute("token", expiryDate);
             AttributeIssuanceDetails result = ThirdPartyAttributeConverter.ParseThirdPartyAttribute(byteValue);
 
             Assert.AreEqual(new DateTime(2019, 1, 2, 3, 4, 5, 678, DateTimeKind.Utc), result.ExpiryDate);
+        }
+
+        [DataTestMethod]
+        [DataRow("2006-01-02", "2006-01-02T00:00:00.000000Z")]
+        [DataRow("2006-01-02T22:04:05Z", "2006-01-02T22:04:05.000000Z")]
+        [DataRow("2006-01-02T22:04:05.1Z", "2006-01-02T22:04:05.100000Z")]
+        [DataRow("2006-01-02T22:04:05.12Z", "2006-01-02T22:04:05.120000Z")]
+        [DataRow("2006-01-02T22:04:05.123Z", "2006-01-02T22:04:05.123000Z")]
+        [DataRow("2006-01-02T22:04:05.1234Z", "2006-01-02T22:04:05.123400Z")]
+        [DataRow("2006-01-02T22:04:05.999999Z", "2006-01-02T22:04:05.999999Z")]
+        [DataRow("2006-01-02T22:04:05.123456Z", "2006-01-02T22:04:05.123456Z")]
+        [DataRow("2002-10-02T10:00:00.1-05:00", "2002-10-02T15:00:00.100000Z")]
+        [DataRow("2002-10-02T10:00:00.12345+11:00", "2002-10-01T23:00:00.123450Z")]
+        public void ShouldParseAllValidRFC3339Dates(string expiryDate, string expectedValue)
+        {
+            byte[] byteValue = CreateSerializedThirdPartyAttribute("token", expiryDate);
+            AttributeIssuanceDetails result = ThirdPartyAttributeConverter.ParseThirdPartyAttribute(byteValue);
+            DateTime nonNullableExpiryDate = (DateTime)result.ExpiryDate;
+
+            string actualString = nonNullableExpiryDate.ToString(Format.RFC3339PatternMilli, DateTimeFormatInfo.InvariantInfo);
+            Assert.AreEqual(expectedValue, actualString);
         }
 
         [TestMethod]

--- a/test/Yoti.Auth.Tests/ShareUrl/Extensions/ThirdPartyAttributeExtensionBuilderTests.cs
+++ b/test/Yoti.Auth.Tests/ShareUrl/Extensions/ThirdPartyAttributeExtensionBuilderTests.cs
@@ -19,8 +19,8 @@ namespace Yoti.Auth.Tests.ShareUrl.Extensions
             var exception = Assert.ThrowsException<InvalidOperationException>(() =>
             {
                 new ThirdPartyAttributeExtensionBuilder()
-                               .WithDefinition(null)
-                               .Build();
+                .WithDefinition(null)
+                .Build();
             });
 
             Assert.IsTrue(exception.Message.Contains("definition"));


### PR DESCRIPTION
See [DateTime.ToString() - Custom date and time format strings](https://docs.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings):
- `fff`: The milliseconds in a date and time value.
- `zzz`: Hours and minutes offset from UTC.
- `ffffff`: The millionths of a second in a date and time value.
- `Z`; Hours offset from UTC, with no leading zeros.

So switching from `fffzzz` to `ffffffZ` produces `2006-01-02T22:04:05.000Z` instead of `2006-01-02T22:04:05.000+00:00`, which are both acceptable RFC3339 formats.
I've updated all the DateTime.ToString() to use this format, to avoid duplication.

