### PR TITLE
SDK-682: Rename tests

### DIFF
--- a/test/Yoti.Auth.Sandbox.Tests/Profile/Request/Attribute/SandboxAnchorTests.cs
+++ b/test/Yoti.Auth.Sandbox.Tests/Profile/Request/Attribute/SandboxAnchorTests.cs
@@ -9,7 +9,7 @@ namespace Yoti.Auth.Sandbox.Tests.Profile.Request.Attribute
         private static SandboxAnchorBuilder _builder;
 
         [Fact]
-        public static void BuilderShouldSetType()
+        public static void BuilderShouldSetEnumType()
         {
             _builder = SandboxAnchor.Builder();
 

--- a/test/Yoti.Auth.Sandbox.Tests/YotiSandboxClientTests.cs
+++ b/test/Yoti.Auth.Sandbox.Tests/YotiSandboxClientTests.cs
@@ -132,7 +132,7 @@ namespace Yoti.Auth.Sandbox
         }
 
         [Fact]
-        public void SetupSharingProfileNonSuccessCode()
+        public void SetupSharingProfileShouldThrowForNonSuccessCode()
         {
             using (var httpResponseMessage = new HttpResponseMessage
             {

--- a/test/Yoti.Auth.Tests/ActivityDetailsParserTests.cs
+++ b/test/Yoti.Auth.Tests/ActivityDetailsParserTests.cs
@@ -9,7 +9,7 @@ namespace Yoti.Auth.Tests
     public class ActivityDetailsParserTests
     {
         [TestMethod]
-        public void UnsuccessfulResponseThrowsYotiProfileException()
+        public void UnsuccessfulResponseShouldThrowYotiProfileException()
         {
             var response = new Response
             {
@@ -23,7 +23,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void NullOrEmptyContentThrowsProfileException()
+        public void NullOrEmptyContentShouldThrowProfileException()
         {
             var response = new Response
             {

--- a/test/Yoti.Auth.Tests/ActivityTests.cs
+++ b/test/Yoti.Auth.Tests/ActivityTests.cs
@@ -50,7 +50,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void SelfieJpegAddedToProfile()
+        public void JpegSelfieShouldBeAddedToProfile()
         {
             var attribute = new ProtoBuf.Attribute.Attribute
             {
@@ -69,7 +69,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void SelfiePngAddedToProfile()
+        public void PngSelfieShouldBeAddedToProfile()
         {
             var attribute = new ProtoBuf.Attribute.Attribute
             {
@@ -90,7 +90,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void FullNameAddedToProfile()
+        public void FullNameShouldBeAddedToProfile()
         {
             var attribute = new ProtoBuf.Attribute.Attribute
             {
@@ -105,7 +105,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void GivenNamesAddedToProfile()
+        public void GivenNamesShouldBeAddedToProfile()
         {
             var attribute = new ProtoBuf.Attribute.Attribute
             {
@@ -120,7 +120,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void FamilyNameAddedToProfile()
+        public void FamilyNameShouldBeAddedToProfile()
         {
             var attribute = new ProtoBuf.Attribute.Attribute
             {
@@ -135,7 +135,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void MobileNumberAddedToProfile()
+        public void MobileNumberShouldBeAddedToProfile()
         {
             var attribute = new ProtoBuf.Attribute.Attribute
             {
@@ -150,7 +150,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void EmailAddressAddedToProfile()
+        public void EmailAddressShouldBeAddedToProfile()
         {
             var attribute = new ProtoBuf.Attribute.Attribute
             {
@@ -165,7 +165,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void DateOfBirthAddedToProfile()
+        public void DateOfBirthShouldBeAddedToProfile()
         {
             var attribute = new ProtoBuf.Attribute.Attribute
             {
@@ -181,7 +181,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void AddressAddedToProfile()
+        public void AddressShouldBeAddedToProfile()
         {
             var attribute = new ProtoBuf.Attribute.Attribute
             {
@@ -196,7 +196,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void UKStructuredPostalAddressAddedToProfile()
+        public void UKStructuredPostalAddressShouldBeAddedToProfile()
         {
             const string addressFormat = "1";
             const string buildingNumber = "15a";
@@ -238,7 +238,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void IndiaStructuredPostalAddressAddedToProfile()
+        public void IndiaStructuredPostalAddressShouldBeAddedToProfile()
         {
             const string rajguraNagar = "Rajguru Nagar";
 
@@ -297,7 +297,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void USAStructuredPostalAddressAddedToProfile()
+        public void USAStructuredPostalAddressShouldBeAddedToProfile()
         {
             const string addressFormat = "3";
             const string addressLineOne = "1512 Ferry Street";
@@ -339,7 +339,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void NestedJSONStructuredPostalAddressAddedToProfile()
+        public void NestedJSONStructuredPostalAddressShouldBeAddedToProfile()
         {
             object nestedValueObject;
             using (StreamReader r = File.OpenText("TestData/NestedJSON.json"))
@@ -406,7 +406,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void AddressIsTakenFromFormattedAddressIfNull()
+        public void AddressShouldBeTakenFromFormattedAddressIfNull()
         {
             const string addressFormat = "1";
             const string buildingNumber = "15a";
@@ -442,7 +442,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void AddressIsNotTakenFromFormattedAddressIfAddressIsPresent()
+        public void AddressShouldNotBeTakenFromFormattedAddressIfAddressIsPresent()
         {
             const string addressFormat = "1";
             const string buildingNumber = "15a";
@@ -487,7 +487,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void GenderAddedToProfile()
+        public void GenderShouldBeAddedToProfile()
         {
             var attribute = new ProtoBuf.Attribute.Attribute
             {
@@ -502,7 +502,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void NationalityAddedToProfile()
+        public void NationalityShouldBeAddedToProfile()
         {
             var attribute = new ProtoBuf.Attribute.Attribute
             {
@@ -517,7 +517,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void DocumentDetailsAddedToProfile()
+        public void DocumentDetailsShouldBeAddedToProfile()
         {
             string issuingCountry = "GBR";
             string documentNumber = "1234abc";
@@ -552,7 +552,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void DocumentImagesAttributeIsAddedToProfile()
+        public void DocumentImagesAttributeShouldBeAddedToProfile()
         {
             var multiValueProtobufAttribute = TestTools.Attributes.CreateProtobufAttributeFromRawAnchor(TestData.TestAttributes.MultiValueAttribute);
 
@@ -583,7 +583,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void NestedMultiValueIsAddedToProfile()
+        public void NestedMultiValueShouldBeAddedToProfile()
         {
             var attributeName = "multiValueName";
 
@@ -610,7 +610,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void UndefinedContentTypeIsConvertedToString()
+        public void UndefinedContentTypeShouldBeConvertedToString()
         {
             var attribute = new ProtoBuf.Attribute.Attribute
             {
@@ -625,7 +625,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void NewContentTypeIsRetrieved()
+        public void NewContentTypeShouldBeRetrieved()
         {
             string name = "newType";
             var attribute = new ProtoBuf.Attribute.Attribute

--- a/test/Yoti.Auth.Tests/AmlProfileTests.cs
+++ b/test/Yoti.Auth.Tests/AmlProfileTests.cs
@@ -7,7 +7,7 @@ namespace Yoti.Auth.Tests
     public class AmlObjectsTests
     {
         [TestMethod]
-        public void AmlProfile_Getters()
+        public void GettersShouldRetrieveProfile()
         {
             const string givenNames = "Edward Richard George";
             const string familyName = "Heath";
@@ -27,7 +27,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void AmlAddress_Getters()
+        public void GettersShouldRetrieveAddress()
         {
             const string country = "UK";
             const string postcode = "AA01 0AA";

--- a/test/Yoti.Auth.Tests/Anchors/AnchorTests.cs
+++ b/test/Yoti.Auth.Tests/Anchors/AnchorTests.cs
@@ -25,7 +25,7 @@ namespace Yoti.Auth.Tests.Anchors
         private const string DateOfBirthString = "1980-01-13";
 
         [TestMethod]
-        public void AnchorGetters()
+        public void AnchorGettersShouldRetrieveCorrectValues()
         {
             ProtoBuf.Attribute.Attribute attribute = TestTools.Anchors.BuildAnchoredAttribute(
                Constants.UserProfile.GivenNamesAttribute,
@@ -58,7 +58,7 @@ namespace Yoti.Auth.Tests.Anchors
         }
 
         [TestMethod]
-        public void GetSourcesIncludesDrivingLicense()
+        public void DrivingLicenseShouldBeAddedToAttribute()
         {
             ProtoBuf.Attribute.Attribute attribute = TestTools.Anchors.BuildAnchoredAttribute(
                 Constants.UserProfile.StructuredPostalAddressAttribute,
@@ -75,7 +75,7 @@ namespace Yoti.Auth.Tests.Anchors
         }
 
         [TestMethod]
-        public void GetSourcesIncludesPassport()
+        public void PassportShouldBeAddedToAttribute()
         {
             ProtoBuf.Attribute.Attribute attribute = TestTools.Anchors.BuildAnchoredAttribute(
                 Constants.UserProfile.DateOfBirthAttribute,
@@ -92,7 +92,7 @@ namespace Yoti.Auth.Tests.Anchors
         }
 
         [TestMethod]
-        public void GetSourcesIncludesYotiAdmin()
+        public void YotiAdminShouldBeAddedToAttribute()
         {
             ProtoBuf.Attribute.Attribute attribute = TestTools.Anchors.BuildAnchoredAttribute(
                 Constants.UserProfile.SelfieAttribute,
@@ -109,7 +109,7 @@ namespace Yoti.Auth.Tests.Anchors
         }
 
         [TestMethod]
-        public void RetrievingAnUnknownAnchor()
+        public void UnknownAnchorShouldHaveCorrectValues()
         {
             ProtoBuf.Attribute.Attribute attribute = TestTools.Anchors.BuildAnchoredAttribute(
                 Constants.UserProfile.NationalityAttribute,

--- a/test/Yoti.Auth.Tests/ApplicationProfileTests.cs
+++ b/test/Yoti.Auth.Tests/ApplicationProfileTests.cs
@@ -13,7 +13,7 @@ namespace Yoti.Auth.Tests
         private readonly string _value = "value";
 
         [TestMethod]
-        public void ApplicationProfile_NameAttribute()
+        public void NameShouldBeRetrieved()
         {
             var initialAttribute = new YotiAttribute<string>(
               name: Constants.ApplicationProfile.ApplicationNameAttribute,
@@ -28,7 +28,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void ApplicationProfile_URLAttribute()
+        public void URLShouldBeRetrieved()
         {
             var initialAttribute = new YotiAttribute<string>(
                 name: Constants.ApplicationProfile.ApplicationURLAttribute,
@@ -43,7 +43,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void ApplicationProfile_LogoAttribute()
+        public void LogoShouldBeRetrieved()
         {
             var initialAttribute = new YotiAttribute<Image>(
               name: Constants.ApplicationProfile.ApplicationLogoAttribute,
@@ -58,7 +58,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void ApplicationProfile_ReceiptBgColorAttribute()
+        public void ReceiptBgColorShouldBeRetrieved()
         {
             var initialAttribute = new YotiAttribute<string>(
                 name: Constants.ApplicationProfile.ApplicationReceiptBgColorAttribute,
@@ -73,7 +73,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void ApplicationProfile_GetAttribute_String()
+        public void StringShouldBeRetrieved()
         {
             var initialAttribute = new YotiAttribute<string>(
                 name: Constants.ApplicationProfile.ApplicationNameAttribute,
@@ -88,7 +88,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void ApplicationProfile_GetAttribute_Image()
+        public void ImageShouldBeRetrieved()
         {
             var initialAttribute = new YotiAttribute<Image>(
                 name: Constants.ApplicationProfile.ApplicationLogoAttribute,
@@ -103,7 +103,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void ApplicationProfile_GetAttribute_WithWrongType()
+        public void WrongAttributeTypeShouldThrowException()
         {
             var initialAttribute = new YotiAttribute<string>(
                 name: Constants.ApplicationProfile.ApplicationNameAttribute,
@@ -119,7 +119,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void ApplicationProfile_GetAttributeNotPresent()
+        public void GetAttributeShouldReturnNullWhenNoAttributePresent()
         {
             var applicationProfile = new ApplicationProfile();
 

--- a/test/Yoti.Auth.Tests/AttributeConverterTests.cs
+++ b/test/Yoti.Auth.Tests/AttributeConverterTests.cs
@@ -15,7 +15,7 @@ namespace Yoti.Auth.Tests
         private readonly ByteString _emptyByteStringValue = ByteString.CopyFromUtf8("");
 
         [TestMethod]
-        public void FailureInAttributeParsing_ShouldNotStopOtherAttributes()
+        public void FailureInAttributeParsingShouldNotStopOtherAttributes()
         {
             string jsonValue = "{}";
             ByteString byteJsonValue = ByteString.CopyFromUtf8(jsonValue);
@@ -39,7 +39,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void StringAttributeWithEmptyValueIsAdded()
+        public void StringAttributeWithEmptyValueShouldBeAdded()
         {
             AttributeList attributeList = CreateAttributeListWithSingleAttribute(
                 Constants.UserProfile.FullNameAttribute,
@@ -59,7 +59,7 @@ namespace Yoti.Auth.Tests
         [DataRow(ContentType.Undefined)]
         [DataRow(ContentType.MultiValue)]
         [DataRow(ContentType.Int)]
-        public void OtherAttributesWithEmptyValueAreNotAdded(ContentType contentType)
+        public void OtherAttributesWithEmptyValueShouldNotBeAdded(ContentType contentType)
         {
             AttributeList attributeList = CreateAttributeListWithSingleAttribute(
                 Constants.UserProfile.FullNameAttribute,
@@ -78,7 +78,7 @@ namespace Yoti.Auth.Tests
         [DataRow(ContentType.Undefined)]
         [DataRow(ContentType.MultiValue)]
         [DataRow(ContentType.Int)]
-        public void OtherAttributesWithEmptyValueThrowsException(ContentType contentType)
+        public void OtherAttributesWithEmptyValueShouldThrowException(ContentType contentType)
         {
             ProtoBuf.Attribute.Attribute attribute = CreateProtobufAttribute("attributeName", _emptyByteStringValue, contentType);
 

--- a/test/Yoti.Auth.Tests/ShareUrl/Policy/DynamicPolicyBuilderTests.cs
+++ b/test/Yoti.Auth.Tests/ShareUrl/Policy/DynamicPolicyBuilderTests.cs
@@ -12,7 +12,7 @@ namespace Yoti.Auth.Tests.ShareUrl.Policy
         private readonly int _expectedPinAuthValue = 2;
 
         [TestMethod]
-        public void EnsuresAnAttributeCanOnlyExistOnce()
+        public void AttributeShouldOnlyExistOnce()
         {
             WantedAttribute wantedAttribute = new WantedAttributeBuilder()
                 .WithName("SomeAttributeName")
@@ -28,7 +28,7 @@ namespace Yoti.Auth.Tests.ShareUrl.Policy
         }
 
         [TestMethod]
-        public void BuildWithAttributes()
+        public void ShouldContainAllAddedAttributes()
         {
             DynamicPolicy dynamicPolicy = new DynamicPolicyBuilder()
                 .WithFamilyName()
@@ -44,7 +44,6 @@ namespace Yoti.Auth.Tests.ShareUrl.Policy
                 .WithEmail()
                 .WithDocumentDetails()
                 .WithDocumentImages()
-
                 .WithAgeOver(55)
                 .WithAgeUnder(18)
                 .Build();
@@ -72,7 +71,7 @@ namespace Yoti.Auth.Tests.ShareUrl.Policy
         }
 
         [TestMethod]
-        public void BuildWithMultipleAgeDerivedAttributes()
+        public void ShouldBuildWithMultipleAgeDerivedAttributes()
         {
             DynamicPolicy dynamicPolicy = new DynamicPolicyBuilder()
                 .WithDateOfBirth()
@@ -144,7 +143,7 @@ namespace Yoti.Auth.Tests.ShareUrl.Policy
         }
 
         [TestMethod]
-        public void BuildsWithAuthTypesTrue()
+        public void ShouldBuildWithAuthTypesTrue()
         {
             DynamicPolicy dynamicPolicy = new DynamicPolicyBuilder()
                 .WithSelfieAuthentication(enabled: true)
@@ -159,7 +158,7 @@ namespace Yoti.Auth.Tests.ShareUrl.Policy
         }
 
         [TestMethod]
-        public void BuildsWithAuthTypesFalse()
+        public void ShouoldBuildWithAuthTypesFalse()
         {
             DynamicPolicy dynamicPolicy = new DynamicPolicyBuilder()
                 .WithSelfieAuthentication(enabled: false)
@@ -172,7 +171,7 @@ namespace Yoti.Auth.Tests.ShareUrl.Policy
         }
 
         [TestMethod]
-        public void BuildsWithAuthTypeEnabledThenDisabled()
+        public void ShouldBuildWithAuthTypeEnabledThenDisabled()
         {
             DynamicPolicy dynamicPolicy = new DynamicPolicyBuilder()
                 .WithAuthType(24, enabled: true)
@@ -185,7 +184,7 @@ namespace Yoti.Auth.Tests.ShareUrl.Policy
         }
 
         [TestMethod]
-        public void BuildsWithAuthTypeDisabledThenEnabled()
+        public void ShouldBuildWithAuthTypeDisabledThenEnabled()
         {
             DynamicPolicy dynamicPolicy = new DynamicPolicyBuilder()
                 .WithAuthType(23, enabled: false)
@@ -199,7 +198,7 @@ namespace Yoti.Auth.Tests.ShareUrl.Policy
         }
 
         [TestMethod]
-        public void BuildsWithSelfieAuthenticationEnabledThenDisabled()
+        public void ShouldBuildWithSelfieAuthenticationEnabledThenDisabled()
         {
             DynamicPolicy dynamicPolicy = new DynamicPolicyBuilder()
                 .WithSelfieAuthentication(enabled: true)
@@ -212,7 +211,7 @@ namespace Yoti.Auth.Tests.ShareUrl.Policy
         }
 
         [TestMethod]
-        public void BuildsWithSelfieAuthenticationDisabledThenEnabled()
+        public void ShouldBuildWithSelfieAuthenticationDisabledThenEnabled()
         {
             DynamicPolicy dynamicPolicy = new DynamicPolicyBuilder()
                 .WithSelfieAuthentication(enabled: false)
@@ -226,7 +225,7 @@ namespace Yoti.Auth.Tests.ShareUrl.Policy
         }
 
         [TestMethod]
-        public void BuildsWithSelfieAuthenticationDisabled()
+        public void ShouldBuildWithSelfieAuthenticationDisabled()
         {
             DynamicPolicy dynamicPolicy = new DynamicPolicyBuilder()
                 .WithSelfieAuthentication(enabled: false)
@@ -238,7 +237,7 @@ namespace Yoti.Auth.Tests.ShareUrl.Policy
         }
 
         [TestMethod]
-        public void FiltersSelfieAuthenticationDuplicates()
+        public void ShouldFilterSelfieAuthenticationDuplicates()
         {
             DynamicPolicy dynamicPolicy = new DynamicPolicyBuilder()
                 .WithSelfieAuthentication(enabled: true)
@@ -252,7 +251,7 @@ namespace Yoti.Auth.Tests.ShareUrl.Policy
         }
 
         [TestMethod]
-        public void FiltersPinAuthenticationDuplicates()
+        public void ShouldFilterPinAuthenticationDuplicates()
         {
             DynamicPolicy dynamicPolicy = new DynamicPolicyBuilder()
                 .WithPinAuthentication(enabled: true)
@@ -266,7 +265,7 @@ namespace Yoti.Auth.Tests.ShareUrl.Policy
         }
 
         [TestMethod]
-        public void BuildsWithPinAuthenticationEnabledThenDisabled()
+        public void ShouldBuildWithPinAuthenticationEnabledThenDisabled()
         {
             DynamicPolicy dynamicPolicy = new DynamicPolicyBuilder()
                 .WithPinAuthentication(enabled: true)
@@ -279,7 +278,7 @@ namespace Yoti.Auth.Tests.ShareUrl.Policy
         }
 
         [TestMethod]
-        public void BuildsWithPinAuthenticationDisabledThenEnabled()
+        public void ShouldBuildWithPinAuthenticationDisabledThenEnabled()
         {
             DynamicPolicy dynamicPolicy = new DynamicPolicyBuilder()
                 .WithPinAuthentication(enabled: false)
@@ -293,7 +292,7 @@ namespace Yoti.Auth.Tests.ShareUrl.Policy
         }
 
         [TestMethod]
-        public void BuildsWithPinAuthenticationDisabled()
+        public void ShouldBuildWithPinAuthenticationDisabled()
         {
             DynamicPolicy dynamicPolicy = new DynamicPolicyBuilder()
                 .WithPinAuthentication(enabled: false)
@@ -305,7 +304,7 @@ namespace Yoti.Auth.Tests.ShareUrl.Policy
         }
 
         [TestMethod]
-        public void BuildsWithRememberMeFlag()
+        public void ShouldBuildWithRememberMeFlag()
         {
             DynamicPolicy result = new DynamicPolicyBuilder()
                 .WithRememberMeId(true)

--- a/test/Yoti.Auth.Tests/UserProfileTests.cs
+++ b/test/Yoti.Auth.Tests/UserProfileTests.cs
@@ -11,7 +11,7 @@ namespace Yoti.Auth.Tests
     public class UserProfileTests
     {
         [TestMethod]
-        public void GetAttributeByName_Datetime()
+        public void GetAttributeByNameShouldRetrieveDatetime()
         {
             DateTime value = new DateTime(1990, 1, 13);
             var initialAttribute = new YotiAttribute<DateTime>(
@@ -28,7 +28,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void GetAttributeByName_String()
+        public void GetAttributeByNameShouldRetrieveString()
         {
             var initialAttribute = new YotiAttribute<string>(
                 name: Constants.UserProfile.NationalityAttribute,
@@ -44,7 +44,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void GetAttributeByName_Bool()
+        public void GetAttributeByNameShouldRetrieveBool()
         {
             bool boolValue = true;
             string attributeName = "Bool";
@@ -63,7 +63,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void GetAttributeByName_Image()
+        public void GetAttributeByNameShouldRetrieveImage()
         {
             Image imageValue = new PngImage(Encoding.UTF8.GetBytes("Value"));
 

--- a/test/Yoti.Auth.Tests/Verifications/AgeVerificationTests.cs
+++ b/test/Yoti.Auth.Tests/Verifications/AgeVerificationTests.cs
@@ -37,7 +37,7 @@ namespace Yoti.Auth.Tests.Verifications
         private readonly List<YotiAttribute<string>> _emptyAttributeStringList = new List<YotiAttribute<string>>();
 
         [TestMethod]
-        public void AgeVerifications_ShouldBeNullSafe()
+        public void AgeVerificationsShouldBeNullSafe()
         {
             ReadOnlyCollection<AgeVerification> result = new YotiProfile().AgeVerifications;
 
@@ -45,7 +45,7 @@ namespace Yoti.Auth.Tests.Verifications
         }
 
         [TestMethod]
-        public void AgeVerifications_IncludesAllResults()
+        public void AgeVerificationsShouldIncludeAllResults()
         {
             var mockBaseProfile = new Mock<IBaseProfile>();
             mockBaseProfile.Setup(x => x.FindAttributesStartingWith<string>(Constants.UserProfile.AgeOverAttribute))
@@ -64,7 +64,7 @@ namespace Yoti.Auth.Tests.Verifications
         }
 
         [TestMethod]
-        public void FindAgeOverVerification_returnsNullForNoMatch()
+        public void FindAgeOverVerificationShouldReturnNullForNoMatch()
         {
             var mockBaseProfile = new Mock<IBaseProfile>();
             mockBaseProfile.Setup(
@@ -77,7 +77,7 @@ namespace Yoti.Auth.Tests.Verifications
         }
 
         [TestMethod]
-        public void FindAgeOverVerification_ReturnsCorrectResult()
+        public void FindAgeOverVerificationShouldReturnCorrectResult()
         {
             int age = 18;
             var ageover18List = new List<YotiAttribute<string>> { _ageOver18Attribute };
@@ -101,7 +101,7 @@ namespace Yoti.Auth.Tests.Verifications
         }
 
         [TestMethod]
-        public void FindAgeUnderVerification_returnsNullForNoMatch()
+        public void FindAgeUnderVerificationShouldReturnNullForNoMatch()
         {
             var mockBaseProfile = new Mock<IBaseProfile>();
             mockBaseProfile.Setup(
@@ -114,7 +114,7 @@ namespace Yoti.Auth.Tests.Verifications
         }
 
         [TestMethod]
-        public void FindAgeUnderVerification_ReturnsCorrectResult()
+        public void FindAgeUnderVerificationShouldReturnCorrectResult()
         {
             int age = 21;
 
@@ -136,7 +136,7 @@ namespace Yoti.Auth.Tests.Verifications
         }
 
         [TestMethod]
-        public void ExceptionThrownForNullDerivedAttribute()
+        public void NullDerivedAttributeShouldThrowException()
         {
             var exception = Assert.ThrowsException<ArgumentNullException>(() =>
             {
@@ -153,7 +153,7 @@ namespace Yoti.Auth.Tests.Verifications
         [DataRow(":21")]
         [DataRow("age_over:eighteen")]
         [DataRow("age_over:")]
-        public void ExceptionThrownForInvalidAttributeNames(string attributeName)
+        public void InvalidAttributeNamesShouldThrowException(string attributeName)
         {
             var attribute = new YotiAttribute<string>(
                 name: attributeName,

--- a/test/Yoti.Auth.Tests/Web/RequestBuilderTests.cs
+++ b/test/Yoti.Auth.Tests/Web/RequestBuilderTests.cs
@@ -25,7 +25,7 @@ namespace Yoti.Auth.Tests.Web
         private readonly byte[] _content = Conversion.UtfToBytes("bytes");
 
         [TestMethod]
-        public void DoesNotBuildWithoutKeyPair()
+        public void ShouldNotBuildWithoutKeyPair()
         {
             var argumentNullException = Assert.ThrowsException<ArgumentNullException>(() =>
             {
@@ -40,7 +40,7 @@ namespace Yoti.Auth.Tests.Web
         }
 
         [TestMethod]
-        public void DoesNotBuildWithoutBaseUri()
+        public void ShouldNotBuildWithoutBaseUri()
         {
             var argumentNullException = Assert.ThrowsException<ArgumentNullException>(() =>
             {
@@ -55,7 +55,7 @@ namespace Yoti.Auth.Tests.Web
         }
 
         [TestMethod]
-        public void DoesNotBuildWithoutEndpoint()
+        public void ShouldNotBuildWithoutEndpoint()
         {
             var invalidOperationException = Assert.ThrowsException<InvalidOperationException>(() =>
             {
@@ -70,7 +70,7 @@ namespace Yoti.Auth.Tests.Web
         }
 
         [TestMethod]
-        public void DoesNotBuildWithoutHttpMethod()
+        public void ShouldNotBuildWithoutHttpMethod()
         {
             var argumentNullException = Assert.ThrowsException<ArgumentNullException>(() =>
             {
@@ -85,7 +85,7 @@ namespace Yoti.Auth.Tests.Web
         }
 
         [TestMethod]
-        public void AddsQueryParams()
+        public void ShouldAddQueryParams()
         {
             Request request = CreateRequestBuilder()
                 .WithQueryParam("key", "value")
@@ -95,7 +95,7 @@ namespace Yoti.Auth.Tests.Web
         }
 
         [TestMethod]
-        public void ContentIsAdded()
+        public void ContentShouldBeAdded()
         {
             Request request = CreateRequestBuilder()
                 .WithContent(_content)
@@ -105,7 +105,7 @@ namespace Yoti.Auth.Tests.Web
         }
 
         [TestMethod]
-        public void CustomHeadersAreAdded()
+        public void CustomHeadersShoudlBeAdded()
         {
             Request request = CreateRequestBuilder()
                 .WithHeader("key", "value")
@@ -125,7 +125,7 @@ namespace Yoti.Auth.Tests.Web
         }
 
         [TestMethod]
-        public void ExtraSlashInUriIsntIncluded()
+        public void ExtraSlashInUriShouldntBeIncluded()
         {
             Request request = new RequestBuilder()
                 .WithBaseUri(new Uri("https://test.com/"))
@@ -151,7 +151,7 @@ namespace Yoti.Auth.Tests.Web
         }
 
         [TestMethod]
-        public void TestAgeScanBackgroundRequest()
+        public void AgeScanBackgroundRequestBuildsCorrectly()
         {
             Request backgroundImageRequest = new RequestBuilder()
                 .WithKeyPair(KeyPair.Get())
@@ -169,7 +169,7 @@ namespace Yoti.Auth.Tests.Web
         }
 
         [TestMethod]
-        public void TestAgeScanChecksRequest()
+        public void AgeScanChecksRequestBuildsCorrectly()
         {
             StreamReader privateKeyStream = KeyPair.GetValidKeyStream();
 
@@ -189,7 +189,7 @@ namespace Yoti.Auth.Tests.Web
         }
 
         [TestMethod]
-        public void TestProfileRequest()
+        public void ProfileRequestBuildsCorrectly()
         {
             string token = "cabc7ad2a172f-4974-a7a2-4ff9-36ba2ec9";
 
@@ -207,7 +207,7 @@ namespace Yoti.Auth.Tests.Web
         }
 
         [TestMethod]
-        public void TestAmlRequest()
+        public void AmlRequestBuildsCorrectly()
         {
             Request amlRequest = new RequestBuilder()
                 .WithKeyPair(KeyPair.Get())
@@ -224,7 +224,7 @@ namespace Yoti.Auth.Tests.Web
         }
 
         [TestMethod]
-        public void TestDocScanRequest()
+        public void DocScanRequestBuildsCorrectly()
         {
             StreamReader privateKeyStream = KeyPair.GetValidKeyStream();
 

--- a/test/Yoti.Auth.Tests/YotiAttributeTests.cs
+++ b/test/Yoti.Auth.Tests/YotiAttributeTests.cs
@@ -9,7 +9,7 @@ namespace Yoti.Auth.Tests
     public class YotiAttributeTests
     {
         [TestMethod]
-        public void YotiAttribute_GetImageValue()
+        public void GetValueShouldRetrieveImage()
         {
             byte[] imageBytes = Conversion.UtfToBytes("ImageValue");
 
@@ -25,7 +25,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void YotiAttribute_JpegBase64Uri()
+        public void JpegBase64UriShouldRetrieveCorrectValue()
         {
             byte[] jpegBytes = Conversion.UtfToBytes("jpegData");
             var yotiAttribute = new YotiAttribute<Image>(
@@ -39,7 +39,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void YotiAttribute_PngBase64Uri()
+        public void PngBase64UriShouldRetrieveCorrectValue()
         {
             byte[] pngBytes = Conversion.UtfToBytes("PngData");
             var yotiAttribute = new YotiAttribute<Image>(

--- a/test/Yoti.Auth.Tests/YotiClientEngineTests.cs
+++ b/test/Yoti.Auth.Tests/YotiClientEngineTests.cs
@@ -24,7 +24,7 @@ namespace Yoti.Auth.Tests
         private const string SdkId = "fake-sdk-id";
 
         [TestMethod]
-        public void SharingFailure_ReturnsSharingFailure()
+        public void SharingFailureShouldReturnSharingFailure()
         {
             Mock<HttpMessageHandler> handlerMock = SetupMockMessageHandler(
                 HttpStatusCode.OK,
@@ -41,7 +41,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void NullReceipt_ThrowsException()
+        public void NullReceiptShouldThrowException()
         {
             Mock<HttpMessageHandler> handlerMock = SetupMockMessageHandler(
                 HttpStatusCode.OK,
@@ -58,7 +58,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void ParseProfile_Success()
+        public void SuccessfulShareShouldReturnCorrectValues()
         {
             const string wrappedReceiptKey = "kyHPjq2+Y48cx+9yS/XzmW09jVUylSdhbP+3Q9Tc9p6bCEnyfa8vj38AIu744RzzE+Dc4qkSF21VfzQKtJVILfOXu5xRc7MYa5k3zWhjiesg/gsrv7J4wDyyBpHIJB8TWXnubYMbSYQJjlsfwyxE9kGe0YI08pRo2Tiht0bfR5Z/YrhAk4UBvjp84D+oyug/1mtGhKphA4vgPhQ9/y2wcInYxju7Q6yzOsXGaRUXR38Tn2YmY9OBgjxiTnhoYJFP1X9YJkHeWMW0vxF1RHxgIVrpf7oRzdY1nq28qzRg5+wC7cjRpS2i/CKUAo0oVG4pbpXsaFhaTewStVC7UFtA77JHb3EnF4HcSWMnK5FM7GGkL9MMXQenh11NZHKPWXpux0nLZ6/vwffXZfsiyTIcFL/NajGN8C/hnNBljoQ+B3fzWbjcq5ueUOPwARZ1y38W83UwMynzkud/iEdHLaZIu4qUCRkfSxJg7Dc+O9/BdiffkOn2GyFmNjVeq754DCUypxzMkjYxokedN84nK13OU4afVyC7t5DDxAK/MqAc69NCBRLqMi5f8BMeOZfMcSWPGC9a2Qu8VgG125TuZT4+wIykUhGyj3Bb2/fdPsxwuKFR+E0uqs0ZKvcv1tkNRRtKYBqTacgGK9Yoehg12cyLrITLdjU1fmIDn4/vrhztN5w=";
             const string otherPartyProfileContent = "ChCZAib1TBm9Q5GYfFrS1ep9EnAwQB5shpAPWLBgZgFgt6bCG3S5qmZHhrqUbQr3yL6yeLIDwbM7x4nuT/MYp+LDXgmFTLQNYbDTzrEzqNuO2ZPn9Kpg+xpbm9XtP7ZLw3Ep2BCmSqtnll/OdxAqLb4DTN4/wWdrjnFC+L/oQEECu646";
@@ -109,7 +109,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void EmptyStringParentRememberMeIdIsHandled()
+        public void EmptyStringParentRememberMeIdShouldBeHandled()
         {
             const string wrappedReceiptKey = "kyHPjq2+Y48cx+9yS/XzmW09jVUylSdhbP+3Q9Tc9p6bCEnyfa8vj38AIu744RzzE+Dc4qkSF21VfzQKtJVILfOXu5xRc7MYa5k3zWhjiesg/gsrv7J4wDyyBpHIJB8TWXnubYMbSYQJjlsfwyxE9kGe0YI08pRo2Tiht0bfR5Z/YrhAk4UBvjp84D+oyug/1mtGhKphA4vgPhQ9/y2wcInYxju7Q6yzOsXGaRUXR38Tn2YmY9OBgjxiTnhoYJFP1X9YJkHeWMW0vxF1RHxgIVrpf7oRzdY1nq28qzRg5+wC7cjRpS2i/CKUAo0oVG4pbpXsaFhaTewStVC7UFtA77JHb3EnF4HcSWMnK5FM7GGkL9MMXQenh11NZHKPWXpux0nLZ6/vwffXZfsiyTIcFL/NajGN8C/hnNBljoQ+B3fzWbjcq5ueUOPwARZ1y38W83UwMynzkud/iEdHLaZIu4qUCRkfSxJg7Dc+O9/BdiffkOn2GyFmNjVeq754DCUypxzMkjYxokedN84nK13OU4afVyC7t5DDxAK/MqAc69NCBRLqMi5f8BMeOZfMcSWPGC9a2Qu8VgG125TuZT4+wIykUhGyj3Bb2/fdPsxwuKFR+E0uqs0ZKvcv1tkNRRtKYBqTacgGK9Yoehg12cyLrITLdjU1fmIDn4/vrhztN5w=";
             const string parentRememberMeId = "";
@@ -146,7 +146,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public async Task PerformAmlCheckAsync()
+        public async Task PerformAmlCheckAsyncShouldReturnCorrectValues()
         {
             Mock<HttpMessageHandler> handlerMock = SetupMockMessageHandler(
                 HttpStatusCode.OK,
@@ -174,7 +174,7 @@ namespace Yoti.Auth.Tests
         [DataRow(HttpStatusCode.RequestTimeout)]
         [DataRow(HttpStatusCode.NotFound)]
         [DataRow(HttpStatusCode.Forbidden)]
-        public void AmlBadRequest_ThrowsException(HttpStatusCode httpStatusCode)
+        public void AmlBadRequestShouldThrowException(HttpStatusCode httpStatusCode)
         {
             Mock<HttpMessageHandler> handlerMock = SetupMockMessageHandler(
                 httpStatusCode,
@@ -191,7 +191,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public async Task CreateShareURLAsync()
+        public async Task CreateShareURLAsyncShouldReturnCorrectValues()
         {
             string shareUrl = @"https://yoti.com/shareurl";
             string refId = "NpdmVVGC-28356678-c236-4518-9de4-7a93009ccaf0-c5f92f2a-5539-453e-babc-9b06e1d6b7de";
@@ -217,7 +217,7 @@ namespace Yoti.Auth.Tests
         [DataRow(HttpStatusCode.RequestTimeout)]
         [DataRow(HttpStatusCode.NotFound)]
         [DataRow(HttpStatusCode.Forbidden)]
-        public void ShareURL_NonSuccessStatusCodes_ThrowException(HttpStatusCode httpStatusCode)
+        public void ShareURLNonSuccessStatusCodesShouldThrowException(HttpStatusCode httpStatusCode)
         {
             Mock<HttpMessageHandler> handlerMock = SetupMockMessageHandler(
                 httpStatusCode,

--- a/test/Yoti.Auth.Tests/YotiClientTests.cs
+++ b/test/Yoti.Auth.Tests/YotiClientTests.cs
@@ -11,7 +11,7 @@ namespace Yoti.Auth.Tests
     public class YotiClientTests
     {
         [TestMethod]
-        public void YotiClient_NullSdkId_ThrowsException()
+        public void NullSdkIdShouldThrowException()
         {
             StreamReader keystream = KeyPair.GetValidKeyStream();
             string sdkId = null;
@@ -22,7 +22,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void YotiClient_EmptySdkId_ThrowsException()
+        public void EmptySdkIdShouldThrowException()
         {
             StreamReader keystream = KeyPair.GetValidKeyStream();
             string sdkId = string.Empty;
@@ -33,7 +33,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void YotiClient_NoKeyStream_ThrowsException()
+        public void NoKeyStreamShouldThrowException()
         {
             StreamReader keystream = null;
             string sdkId = "fake-sdk-id";
@@ -44,7 +44,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void YotiClient_InvalidKeyStream_ThrowsException()
+        public void InvalidKeyStreamShouldThrowException()
         {
             StreamReader keystream = KeyPair.GetInvalidFormatKeyStream();
             const string sdkId = "fake-sdk-id";
@@ -55,7 +55,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void YotiClient_PerformAmlCheck_NullAmlProfile_ThrowsException()
+        public void NullAmlProfileShouldThrowException()
         {
             YotiClient client = CreateYotiClient();
 
@@ -68,7 +68,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void YotiClient_PerformAmlCheck_NullAmlAddress_ThrowsException()
+        public void NullAmlAddressShouldThrowException()
         {
             YotiClient client = CreateYotiClient();
 
@@ -86,7 +86,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void YotiClient_PerformAmlCheck_NullGivenName_ThrowsException()
+        public void NullAmlGivenNameShouldThrowException()
         {
             YotiClient client = CreateYotiClient();
 
@@ -104,7 +104,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void YotiClient_PerformAmlCheck_NullFamilyName_ThrowsException()
+        public void NullAmlFamilyNameShouldThrowException()
         {
             YotiClient client = CreateYotiClient();
 
@@ -122,7 +122,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void YotiClient_PerformAmlCheck_NullCountry_ThrowsException()
+        public void NullAmlCountryShouldThrowException()
         {
             YotiClient client = CreateYotiClient();
 
@@ -143,7 +143,7 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void CreateShareUrl_NullDynamicScenario_ThrowsException()
+        public void NullDynamicScenarioShouldThrowException()
         {
             YotiClient client = CreateYotiClient();
 


### PR DESCRIPTION
- This was based on the idea that tests should always describe what they are doing, so it shouldn't be necessary to additionally read through the steps to work out what it is testing. This was the case in most of the tests, but this changeset is ensuring the tests are named consistently throughout.
- I don't think _all_ of the changes were entirely necessary (e.g. just adding "should), but I just thought that whilst I was renaming the tests I might as well make them all consistent.
