### PR TITLE
SDK-1386: Add validation and tests for one time use token varations

### DIFF
--- a/src/Yoti.Auth/CryptoEngine.cs
+++ b/src/Yoti.Auth/CryptoEngine.cs
@@ -81,6 +81,8 @@ namespace Yoti.Auth
 
         internal static string DecryptToken(string encryptedConnectToken, AsymmetricCipherKeyPair keyPair)
         {
+            Validation.NotNullOrEmpty(encryptedConnectToken, "one time use token");
+
             // token was encoded as a URL-safe base64 so it can be transferred in a URL
             byte[] cipherBytes = Conversion.UrlSafeBase64ToBytes(encryptedConnectToken);
 

--- a/test/Yoti.Auth.Tests/CryptoEngineTests.cs
+++ b/test/Yoti.Auth.Tests/CryptoEngineTests.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Yoti.Auth.Tests.Common;
+
+namespace Yoti.Auth.Tests
+{
+    [TestClass]
+    public class CryptoEngineTests
+    {
+        [TestMethod]
+        public void NonBase64TokenThrowsError()
+        {
+            var exception = Assert.ThrowsException<FormatException>(() =>
+            {
+                CryptoEngine.DecryptToken("_aasi", KeyPair.Get());
+            });
+
+            Assert.IsTrue(exception.Message.Contains("The input is not a valid Base-64 string as it contains a non-base 64 character"));
+        }
+
+        [TestMethod]
+        public void EmptyOneTimeUseTokenThrowsError()
+        {
+            var exception = Assert.ThrowsException<InvalidOperationException>(() =>
+            {
+                CryptoEngine.DecryptToken("", KeyPair.Get());
+            });
+
+            Assert.IsTrue(exception.Message.Contains("one time use token"));
+        }
+    }
+}


### PR DESCRIPTION
- Added empty string validation when attempting to decrypt a token