### PR TITLE
SDK-1505: Use .env variable for YOTI_API_URL

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ steps:
     scannerMode: 'MSBuild'
     projectKey: 'getyoti:dotnet'
     projectName: '.NET SDK'
-    projectVersion: '3.3.1'
+    projectVersion: '3.4.0'
     extraProperties: |
       sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml"
       sonar.links.scm = https://github.com/getyoti/yoti-dotnet-sdk

--- a/src/Yoti.Auth/Yoti.Auth.csproj
+++ b/src/Yoti.Auth/Yoti.Auth.csproj
@@ -19,7 +19,7 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <LangVersion>latest</LangVersion>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
-    <Version>3.3.1</Version>
+    <Version>3.4.0</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Yoti.Auth/YotiClient.cs
+++ b/src/Yoti.Auth/YotiClient.cs
@@ -13,7 +13,7 @@ namespace Yoti.Auth
         private readonly string _sdkId;
         private readonly AsymmetricCipherKeyPair _keyPair;
         private readonly YotiClientEngine _yotiClientEngine;
-        private Uri _apiUri = new Uri(Constants.Api.DefaultYotiApiUrl);
+        internal Uri ApiUri { get; private set; }
 
         /// <summary>
         /// Create a <see cref="YotiClient"/>
@@ -48,6 +48,8 @@ namespace Yoti.Auth
 
             _sdkId = sdkId;
             _keyPair = CryptoEngine.LoadRsaKey(privateKeyStream);
+
+            SetYotiApiUri();
 
             _yotiClientEngine = new YotiClientEngine(httpClient);
         }
@@ -90,7 +92,7 @@ namespace Yoti.Auth
         /// <returns>The account details of the logged in user as a <see cref="ActivityDetails"/>.</returns>
         public async Task<ActivityDetails> GetActivityDetailsAsync(string encryptedToken)
         {
-            return await _yotiClientEngine.GetActivityDetailsAsync(encryptedToken, _sdkId, _keyPair, _apiUri).ConfigureAwait(false);
+            return await _yotiClientEngine.GetActivityDetailsAsync(encryptedToken, _sdkId, _keyPair, ApiUri).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -112,7 +114,7 @@ namespace Yoti.Auth
         /// <returns>The result of the AML check in the form of a <see cref="AmlResult"/>.</returns>
         public async Task<AmlResult> PerformAmlCheckAsync(IAmlProfile amlProfile)
         {
-            return await _yotiClientEngine.PerformAmlCheckAsync(_sdkId, _keyPair, _apiUri, amlProfile).ConfigureAwait(false);
+            return await _yotiClientEngine.PerformAmlCheckAsync(_sdkId, _keyPair, ApiUri, amlProfile).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -140,12 +142,24 @@ namespace Yoti.Auth
         /// <returns><see cref="ShareUrlResult"/> containing a Sharing URL and Reference ID</returns>
         public async Task<ShareUrlResult> CreateShareUrlAsync(DynamicScenario dynamicScenario)
         {
-            return await _yotiClientEngine.CreateShareURLAsync(_sdkId, _keyPair, _apiUri, dynamicScenario).ConfigureAwait(false);
+            return await _yotiClientEngine.CreateShareURLAsync(_sdkId, _keyPair, ApiUri, dynamicScenario).ConfigureAwait(false);
+        }
+
+        internal void SetYotiApiUri()
+        {
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("YOTI_API_URL")))
+            {
+                ApiUri = new Uri(Environment.GetEnvironmentVariable("YOTI_API_URL"));
+            }
+            else
+            {
+                ApiUri = new Uri(Constants.Api.DefaultYotiApiUrl);
+            }
         }
 
         public YotiClient OverrideApiUri(Uri apiUri)
         {
-            _apiUri = apiUri;
+            ApiUri = apiUri;
 
             return this;
         }

--- a/test/Yoti.Auth.Tests/Verifications/AgeVerificationTests.cs
+++ b/test/Yoti.Auth.Tests/Verifications/AgeVerificationTests.cs
@@ -144,7 +144,7 @@ namespace Yoti.Auth.Tests.Verifications
             });
 
             Assert.IsTrue(exception.Message.Contains("Value cannot be null."));
-            Assert.IsTrue(exception.Message.Contains("Parameter name: derivedAttribute"));
+            Assert.IsTrue(exception.Message.Contains("Parameter 'derivedAttribute'"));
         }
 
         [DataTestMethod]

--- a/test/Yoti.Auth.Tests/Yoti.Auth.Tests.csproj
+++ b/test/Yoti.Auth.Tests/Yoti.Auth.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>Yoti.Auth.Tests</AssemblyName>
     <PackageId>Yoti.Auth.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -34,10 +34,9 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
     <PackageReference Include="OpenCover" Version="4.7.922" />
-    <PackageReference Include="Microsoft.AspNetCore.All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Yoti.Auth.Tests/YotiClientTests.cs
+++ b/test/Yoti.Auth.Tests/YotiClientTests.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using System.IO;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
+using System;
+using System.IO;
 using Yoti.Auth.Aml;
 using Yoti.Auth.Tests.Common;
 
@@ -153,6 +153,39 @@ namespace Yoti.Auth.Tests
             });
 
             Assert.IsTrue(TestTools.Exceptions.IsExceptionInAggregateException<ArgumentNullException>(aggregateException));
+        }
+
+        [DataTestMethod]
+        [DataRow("")]
+        [DataRow(null)]
+        public void ApiUriDefaultIsUsedForNullOrEmpty(string envVar)
+        {
+            Environment.SetEnvironmentVariable("YOTI_API_URL", envVar);
+            YotiClient client = CreateYotiClient();
+            Uri expectedDefaultUri = new Uri(Constants.Api.DefaultYotiApiUrl);
+
+            Assert.AreEqual(expectedDefaultUri, client.ApiUri);
+        }
+
+        [TestMethod]
+        public void ApiUriOverriddenOverEnvVariable()
+        {
+            Uri overriddenApiUri = new Uri("https://overridden.com");
+            Environment.SetEnvironmentVariable("YOTI_API_URL", "https://envapiuri.com");
+            YotiClient client = CreateYotiClient();
+            client.OverrideApiUri(overriddenApiUri);
+
+            Assert.AreEqual(overriddenApiUri, client.ApiUri);
+        }
+
+        [TestMethod]
+        public void ApiUriEnvVariableIsUsed()
+        {
+            Environment.SetEnvironmentVariable("YOTI_API_URL", "https://envapiuri.com");
+            YotiClient client = CreateYotiClient();
+
+            Uri expectedApiUri = new Uri("https://envapiuri.com");
+            Assert.AreEqual(expectedApiUri, client.ApiUri);
         }
 
         private static YotiClient CreateYotiClient()


### PR DESCRIPTION
- Use .env variable for `YOTI_API_URL` if present,
  - __except__ when overridden with `YotiClient.OverrideApiUri`
- Also updated target framework of tests