### PR TITLE
Update packages, add explicit NetStandard reference

### DIFF
--- a/src/Examples/Profile/47Example/Web.config
+++ b/src/Examples/Profile/47Example/Web.config
@@ -11,7 +11,11 @@
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
   </appSettings>
   <system.web>
-    <compilation debug="true" targetFramework="4.7.2" />
+    <compilation debug="true" targetFramework="4.7.2">
+      <assemblies>
+        <add assembly="netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" />
+      </assemblies>
+    </compilation>
     <httpRuntime targetFramework="4.7.2" />
   </system.web>
   <runtime>

--- a/src/Examples/Profile/47Example/packages.config
+++ b/src/Examples/Profile/47Example/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.5.0.2" targetFramework="net472" />
-  <package id="jQuery" version="3.4.1" targetFramework="net472" />
+  <package id="jQuery" version="3.5.0" targetFramework="net472" />
   <package id="jQuery.Validation" version="1.19.1" targetFramework="net472" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.7" targetFramework="net472" />
   <package id="Microsoft.AspNet.Razor" version="3.2.7" targetFramework="net472" />

--- a/test/Yoti.Auth.Tests/Yoti.Auth.Tests.csproj
+++ b/test/Yoti.Auth.Tests/Yoti.Auth.Tests.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.8.0">
+    <PackageReference Include="coverlet.msbuild" Version="2.8.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
- Update packages, add explicit NetStandard reference
- Netstandard is needed for some references in the `Connect.cshtml` razor view