### PR TITLE
SDK-1587: Format ExpiryDate of ThirdPartyAttributeExtension w/ ms

### DIFF
--- a/src/Yoti.Auth/Constants/Format.cs
+++ b/src/Yoti.Auth/Constants/Format.cs
@@ -2,6 +2,7 @@
 {
     internal static class Format
     {
-        public const string RFC3339PatternMilli = "yyyy-MM-dd'T'HH:mm:ss.ffffffZ";
+        public const string RFC3339PatternMilli = "yyyy-MM-dd'T'HH:mm:ss.fffZ";
+        public const string RFC3339PatternMicro = "yyyy-MM-dd'T'HH:mm:ss.ffffffZ";
     }
 }

--- a/test/Yoti.Auth.Tests/Anchors/SignedTimestampTests.cs
+++ b/test/Yoti.Auth.Tests/Anchors/SignedTimestampTests.cs
@@ -16,7 +16,7 @@ namespace Yoti.Auth.Tests.Anchors
             var protoBufSignedTimestamp = new ProtoBuf.Common.SignedTimestamp { Timestamp = unsignedUnixTimestamp };
 
             var signedTimestamp = new SignedTimestamp(protoBufSignedTimestamp);
-            string result = signedTimestamp.GetTimestamp().ToString(Format.RFC3339PatternMilli, DateTimeFormatInfo.InvariantInfo);
+            string result = signedTimestamp.GetTimestamp().ToString(Format.RFC3339PatternMicro, DateTimeFormatInfo.InvariantInfo);
 
             Assert.AreEqual("1920-03-13T19:50:54.000001Z", result);
         }

--- a/test/Yoti.Auth.Tests/Share/ThirdParty/ThirdPartyAttributeConverterTests.cs
+++ b/test/Yoti.Auth.Tests/Share/ThirdParty/ThirdPartyAttributeConverterTests.cs
@@ -53,7 +53,7 @@ namespace Yoti.Auth.Tests.Share.ThirdParty
             AttributeIssuanceDetails result = ThirdPartyAttributeConverter.ParseThirdPartyAttribute(byteValue);
             DateTime nonNullableExpiryDate = (DateTime)result.ExpiryDate;
 
-            string actualString = nonNullableExpiryDate.ToString(Format.RFC3339PatternMilli, DateTimeFormatInfo.InvariantInfo);
+            string actualString = nonNullableExpiryDate.ToString(Format.RFC3339PatternMicro, DateTimeFormatInfo.InvariantInfo);
             Assert.AreEqual(expectedValue, actualString);
         }
 

--- a/test/Yoti.Auth.Tests/ShareUrl/Extensions/ThirdPartyAttributeExtensionBuilderTests.cs
+++ b/test/Yoti.Auth.Tests/ShareUrl/Extensions/ThirdPartyAttributeExtensionBuilderTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Yoti.Auth.Constants;
 using Yoti.Auth.Share.ThirdParty;
 using Yoti.Auth.ShareUrl.Extensions;
 
@@ -58,6 +59,36 @@ namespace Yoti.Auth.Tests.ShareUrl.Extensions
             List<AttributeDefinition> definitions = extension.Content.Definitions;
             Assert.AreEqual(1, definitions.Count);
             Assert.AreEqual(_someDefinition, definitions[0].Name);
+        }
+
+        [DataTestMethod]
+        [DataRow("2006-01-02T22:04:05Z", "2006-01-02T22:04:05.000Z")]
+        [DataRow("2006-01-02T22:04:05.1Z", "2006-01-02T22:04:05.100Z")]
+        [DataRow("2006-01-02T22:04:05.12Z", "2006-01-02T22:04:05.120Z")]
+        [DataRow("2006-01-02T22:04:05.123Z", "2006-01-02T22:04:05.123Z")]
+        [DataRow("2006-01-02T22:04:05.1234Z", "2006-01-02T22:04:05.123Z")]
+        [DataRow("2006-01-02T22:04:05.999999Z", "2006-01-02T22:04:05.999Z")]
+        [DataRow("2006-01-02T22:04:05.123456Z", "2006-01-02T22:04:05.123Z")]
+        [DataRow("2002-10-02T10:00:00.1-05:00", "2002-10-02T15:00:00.100Z")]
+        [DataRow("2002-10-02T10:00:00.12345+11:00", "2002-10-01T23:00:00.123Z")]
+        [TestMethod]
+        public void ShouldBuildThirdPartyAttributeExtensionWithExpiryDates(string expiryDateInputString, string expectedExpiryDate)
+        {
+            bool parseSuccess = DateTime.TryParse(
+                expiryDateInputString,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AdjustToUniversal,
+                out DateTime expiryDate);
+
+            Assert.IsTrue(parseSuccess);
+
+            Extension<ThirdPartyAttributeContent> extension =
+                new ThirdPartyAttributeExtensionBuilder()
+                .WithDefinition(_someDefinition)
+                .WithExpiryDate(expiryDate)
+                .Build();
+
+            Assert.AreEqual(expectedExpiryDate, extension.Content.ExpiryDate);
         }
 
         [TestMethod]


### PR DESCRIPTION
- The constant used was incorrectly called "RFC3339PatternMilli", when it was actually microseconds.
- Have kept the test "ShouldParseAllValidRFC3339Dates" in ThirdPartyAttributeConverterTests, even though we should only expecte Millisecond timestamps, as didn't see the harm in allowing more.
