### PR TITLE
SDK-1386: Throw exception for null or empty token

### DIFF
--- a/src/Yoti.Auth/YotiClientEngine.cs
+++ b/src/Yoti.Auth/YotiClientEngine.cs
@@ -31,6 +31,8 @@ namespace Yoti.Auth
 
         public async Task<ActivityDetails> GetActivityDetailsAsync(string encryptedConnectToken, string sdkId, AsymmetricCipherKeyPair keyPair, Uri apiUrl)
         {
+            Validation.NotNullOrEmpty(encryptedConnectToken, nameof(encryptedConnectToken));
+
             string token = CryptoEngine.DecryptToken(encryptedConnectToken, keyPair);
             string path = $"profile/{token}";
 

--- a/test/Yoti.Auth.Tests/YotiClientEngineTests.cs
+++ b/test/Yoti.Auth.Tests/YotiClientEngineTests.cs
@@ -23,6 +23,21 @@ namespace Yoti.Auth.Tests
         private static HttpRequestMessage _httpRequestMessage;
         private const string SdkId = "fake-sdk-id";
 
+        [DataTestMethod]
+        [DataRow(null)]
+        [DataRow("")]
+        public void InvalidTokenShouldThrowException(string encryptedToken)
+        {
+            var engine = new YotiClientEngine(new HttpClient());
+
+            var profileException = Assert.ThrowsExceptionAsync<InvalidOperationException>(async () =>
+            {
+                await engine.GetActivityDetailsAsync(encryptedToken, SdkId, _keyPair, new Uri(Constants.Api.DefaultYotiApiUrl));
+            }).Result;
+
+            Assert.IsTrue(profileException.Message.Contains("'encryptedConnectToken' must not be empty or null"));
+        }
+
         [TestMethod]
         public void SharingFailureShouldReturnSharingFailure()
         {


### PR DESCRIPTION
- If the token is an empty string, an unhelpful error is thrown about block size, so this is to add validation before that point