### PR TITLE
SDK-1595: Refactor client initialisation

### DIFF
--- a/src/Yoti.Auth/YotiClient.cs
+++ b/src/Yoti.Auth/YotiClient.cs
@@ -22,7 +22,8 @@ namespace Yoti.Auth
         /// <param name="privateKeyStream">
         /// The private key file provided on the Yoti Hub as a <see cref="StreamReader"/>.
         /// </param>
-        public YotiClient(string sdkId, StreamReader privateKeyStream) : this(new HttpClient(), sdkId, privateKeyStream)
+        public YotiClient(string sdkId, StreamReader privateKeyStream)
+            : this(new HttpClient(), sdkId, privateKeyStream)
         {
         }
 
@@ -35,23 +36,18 @@ namespace Yoti.Auth
         /// The private key file provided on the Yoti Hub as a <see cref="StreamReader"/>.
         /// </param>
         public YotiClient(HttpClient httpClient, string sdkId, StreamReader privateKeyStream)
+            : this(httpClient, sdkId, CryptoEngine.LoadRsaKey(privateKeyStream))
         {
-            if (string.IsNullOrEmpty(sdkId))
-            {
-                throw new ArgumentNullException(nameof(sdkId));
-            }
+        }
 
-            if (privateKeyStream == null)
-            {
-                throw new ArgumentNullException(nameof(privateKeyStream));
-            }
-
-            _sdkId = sdkId;
-            _keyPair = CryptoEngine.LoadRsaKey(privateKeyStream);
-
-            SetYotiApiUri();
-
-            _yotiClientEngine = new YotiClientEngine(httpClient);
+        /// <summary>
+        /// Create a <see cref="YotiClient"/> with a specified <see cref="HttpClient"/>
+        /// </summary>
+        /// <param name="sdkId">The client SDK ID provided on the Yoti Hub.</param>
+        /// <param name="keyPair">The key pair from the Yoti Hub.</param>
+        public YotiClient(string sdkId, AsymmetricCipherKeyPair keyPair)
+            : this(new HttpClient(), sdkId, keyPair)
+        {
         }
 
         /// <summary>
@@ -62,11 +58,13 @@ namespace Yoti.Auth
         /// <param name="keyPair">The key pair from the Yoti Hub.</param>
         public YotiClient(HttpClient httpClient, string sdkId, AsymmetricCipherKeyPair keyPair)
         {
-            Validation.NotNull(sdkId, nameof(sdkId));
+            Validation.NotNullOrEmpty(sdkId, nameof(sdkId));
             Validation.NotNull(keyPair, nameof(keyPair));
 
             _sdkId = sdkId;
             _keyPair = keyPair;
+
+            SetYotiApiUri();
 
             _yotiClientEngine = new YotiClientEngine(httpClient);
         }

--- a/src/Yoti.Auth/YotiClient.cs
+++ b/src/Yoti.Auth/YotiClient.cs
@@ -23,7 +23,7 @@ namespace Yoti.Auth
         /// The private key file provided on the Yoti Hub as a <see cref="StreamReader"/>.
         /// </param>
         public YotiClient(string sdkId, StreamReader privateKeyStream)
-            : this(new HttpClient(), sdkId, privateKeyStream)
+            : this(new HttpClient(), sdkId, CryptoEngine.LoadRsaKey(privateKeyStream))
         {
         }
 
@@ -37,16 +37,6 @@ namespace Yoti.Auth
         /// </param>
         public YotiClient(HttpClient httpClient, string sdkId, StreamReader privateKeyStream)
             : this(httpClient, sdkId, CryptoEngine.LoadRsaKey(privateKeyStream))
-        {
-        }
-
-        /// <summary>
-        /// Create a <see cref="YotiClient"/> with a specified <see cref="HttpClient"/>
-        /// </summary>
-        /// <param name="sdkId">The client SDK ID provided on the Yoti Hub.</param>
-        /// <param name="keyPair">The key pair from the Yoti Hub.</param>
-        public YotiClient(string sdkId, AsymmetricCipherKeyPair keyPair)
-            : this(new HttpClient(), sdkId, keyPair)
         {
         }
 

--- a/test/Yoti.Auth.Tests/YotiClientTests.cs
+++ b/test/Yoti.Auth.Tests/YotiClientTests.cs
@@ -204,16 +204,6 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
-        public void ApiUriSetForPrivateKeyInitialisation()
-        {
-            AsymmetricCipherKeyPair keyPair = KeyPair.Get();
-
-            YotiClient yotiClient = new YotiClient(_someSdkId, keyPair);
-
-            Assert.AreEqual(_expectedDefaultUri, yotiClient.ApiUri);
-        }
-
-        [TestMethod]
         public void ApiUriSetForPrivateKeyInitialisationHttpClient()
         {
             AsymmetricCipherKeyPair keyPair = KeyPair.Get();


### PR DESCRIPTION
- The API URL setting method was not called for `YotiClient(HttpClient httpClient, string sdkId, AsymmetricCipherKeyPair keyPair)`
- Refactor client initialisation so that entrypoints go through the same path

I attempted to add "YotiClient(string sdkId, AsymmetricCipherKeyPair keyPair)" as an initialiser option.
This strangely causes a problem when building the .NET 4.7 Example project. When initialising the YotiClient with a **DIFFERENT** initialiser, the codepath does not go through this new method, but the compiler seems to get confused, and think that a reference is required to BouncyCastle/Portable.BouncyCastle.

I think this is a bug with .NET. Using named parameters from integrator's code gets round this, but I think having clients specify `new HttpClient()` when calling with `AsymmetricCipherKeyPair` (rather than `StreamReader`) if they need to, is more preferable than having them specify named parameters OR adding the portable.BouncyCastle reference.