### PR TITLE
SDK-1670: Base64 URL tokens

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ steps:
     scannerMode: 'MSBuild'
     projectKey: 'getyoti:dotnet'
     projectName: '.NET SDK'
-    projectVersion: '3.6.0'
+    projectVersion: '3.6.1'
     extraProperties: |
       sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml"
       sonar.links.scm = https://github.com/getyoti/yoti-dotnet-sdk

--- a/src/Yoti.Auth/Conversion.cs
+++ b/src/Yoti.Auth/Conversion.cs
@@ -29,14 +29,38 @@ namespace Yoti.Auth
         /// UrlSafe Base64 uses '-' instead of '+', and '_' instead of '/' so it can be passed as a
         /// URL parameter without extra encoding.
         /// </summary>
-        public static byte[] UrlSafeBase64ToBytes(string urlSafeBase64)
+        public static byte[] UrlSafeBase64ToBytes(string urlSafeBase64, bool padded = true)
         {
 #if NETCOREAPP2_2 || NETCOREAPP3_1 || NETSTANDARD2_1
             string base64 = urlSafeBase64.Replace("-", "+", StringComparison.Ordinal).Replace("_", "/", StringComparison.Ordinal);
 #else
             string base64 = urlSafeBase64.Replace("-", "+").Replace("_", "/");
 #endif
+
+            if (!padded)
+            {
+                switch (base64.Length % 4)
+                {
+                    case 2: base64 += "=="; break;
+                    case 3: base64 += "="; break;
+                }
+            }
             return Base64ToBytes(base64);
+        }
+
+        public static string BytesToUrlSafeBase64(byte[] bytes, bool padded = true)
+        {
+            string base64 = BytesToBase64(bytes);
+
+#if NETCOREAPP2_2 || NETCOREAPP3_1 || NETSTANDARD2_1
+            string urlSafeBase64 = base64.Replace("+", "-", StringComparison.Ordinal).Replace("/", "_", StringComparison.Ordinal);
+#else
+            string urlSafeBase64 = base64.Replace("+", "-").Replace("/", "_");
+#endif
+            if (!padded) {
+                urlSafeBase64 = urlSafeBase64.TrimEnd('=');
+            }
+            return urlSafeBase64;
         }
     }
 }

--- a/src/Yoti.Auth/Share/ThirdParty/ThirdPartyAttributeConverter.cs
+++ b/src/Yoti.Auth/Share/ThirdParty/ThirdPartyAttributeConverter.cs
@@ -18,7 +18,7 @@ namespace Yoti.Auth.Share.ThirdParty
             IssuingAttributes issuingAttributes = ParseIssuingAttributes(thirdPartyAttribute.IssuingAttributes);
 
             ByteString token = thirdPartyAttribute.IssuanceToken;
-            string base64Token = Conversion.BytesToBase64(token.ToByteArray());
+            string base64Token = Conversion.BytesToUrlSafeBase64(token.ToByteArray(), false);
 
             DateTime? expiryDate = issuingAttributes.ExpiryDate;
             List<AttributeDefinition> attributeDefinitions = issuingAttributes.AttributeDefinitions;

--- a/src/Yoti.Auth/Yoti.Auth.csproj
+++ b/src/Yoti.Auth/Yoti.Auth.csproj
@@ -19,7 +19,7 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <LangVersion>latest</LangVersion>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
-    <Version>3.6.0</Version>
+    <Version>3.6.1</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/Yoti.Auth.Tests/ConversionTests.cs
+++ b/test/Yoti.Auth.Tests/ConversionTests.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Yoti.Auth.Exceptions;
+
+namespace Yoti.Auth.Tests
+{
+    [TestClass]
+    public class ConversionTests
+    {
+        [DataTestMethod]
+        [DataRow("HT-sGfUaHj-rDA", "HT+sGfUaHj+rDA==")]
+        [DataRow("-OyhuDs6dAg", "+OyhuDs6dAg=")]
+        [DataRow("c3RyaW5n", "c3RyaW5n")]
+        public void UrlSafeBase64ToBytesShouldDecodeUnpaddedCorrectly(string b64UrlUnpadded, string b64)
+        {
+            Assert.AreEqual(
+                Conversion.BytesToBase64(Conversion.UrlSafeBase64ToBytes(b64UrlUnpadded, false)),
+                b64
+            );
+        }
+
+        [DataTestMethod]
+        [DataRow("HT-sGfUaHj-rDA==", "HT+sGfUaHj+rDA==")]
+        [DataRow("-OyhuDs6dAg=", "+OyhuDs6dAg=")]
+        [DataRow("c3RyaW5n", "c3RyaW5n")]
+        public void UrlSafeBase64ToBytesShouldDecodePaddedCorrectly(string b64UrlPadded, string b64)
+        {
+            Assert.AreEqual(
+                Conversion.BytesToBase64(Conversion.UrlSafeBase64ToBytes(b64UrlPadded)),
+                b64
+            );
+        }
+
+
+        [DataTestMethod]
+        [DataRow("HT-sGfUaHj-rDA", "HT+sGfUaHj+rDA==")]
+        [DataRow("-OyhuDs6dAg", "+OyhuDs6dAg=")]
+        [DataRow("c3RyaW5n", "c3RyaW5n")]
+        public void BytesToUrlSafeBase64ShouldEncodeUnpaddedCorrectly(string b64UrlUnpadded, string b64)
+        {
+            Assert.AreEqual(
+                Conversion.BytesToUrlSafeBase64(Conversion.Base64ToBytes(b64), false),
+                b64UrlUnpadded
+            );
+        }
+
+        [DataTestMethod]
+        [DataRow("HT-sGfUaHj-rDA==", "HT+sGfUaHj+rDA==")]
+        [DataRow("-OyhuDs6dAg=", "+OyhuDs6dAg=")]
+        [DataRow("c3RyaW5n", "c3RyaW5n")]
+        public void BytesToUrlSafeBase64ShouldEncodePaddedCorrectly(string b64UrlPadded, string b64)
+        {
+            Assert.AreEqual(
+                Conversion.BytesToUrlSafeBase64(Conversion.Base64ToBytes(b64)),
+                b64UrlPadded
+            );
+        }
+    }
+}

--- a/test/Yoti.Auth.Tests/Share/ExtraDataConverterTests.cs
+++ b/test/Yoti.Auth.Tests/Share/ExtraDataConverterTests.cs
@@ -23,7 +23,7 @@ namespace Yoti.Auth.Tests.Share
             string actualDateTime = nonNullableExpiryDate.ToString(Format.RFC3339PatternMilli, DateTimeFormatInfo.InvariantInfo);
 
             Assert.AreEqual(expectedDateTime, actualDateTime);
-            Assert.AreEqual("c29tZUlzc3VhbmNlVG9rZW4=", result.AttributeIssuanceDetails.Token);
+            Assert.AreEqual("c29tZUlzc3VhbmNlVG9rZW4", result.AttributeIssuanceDetails.Token);
             Assert.AreEqual(2, result.AttributeIssuanceDetails.IssuingAttributes.Count);
             Assert.AreEqual("com.thirdparty.id", result.AttributeIssuanceDetails.IssuingAttributes[0].Name);
             Assert.AreEqual("com.thirdparty.other_id", result.AttributeIssuanceDetails.IssuingAttributes[1].Name);


### PR DESCRIPTION
> Version `3.6.1`

### Fixed
- Attribute Issuance token is now base64 URL encoded
