### PR TITLE
SDK-1811: Don't assume response always has content

### DIFF
--- a/src/Yoti.Auth/DocScan/DocScanService.cs
+++ b/src/Yoti.Auth/DocScan/DocScanService.cs
@@ -148,6 +148,11 @@ namespace Yoti.Auth.DocScan
                     Response.CreateYotiExceptionFromStatusCode<DocScanException>(response);
                 }
 
+                if (response.Content == null)
+                {
+                    return null;
+                }
+
                 string contentType = response.Content.Headers.ContentType.MediaType;
 
                 return new MediaValue(contentType, response.Content.ReadAsByteArrayAsync().Result);

--- a/test/Yoti.Auth.Tests/DocScan/DocScanClientTests.cs
+++ b/test/Yoti.Auth.Tests/DocScan/DocScanClientTests.cs
@@ -320,6 +320,25 @@ namespace Yoti.Auth.Tests.DocScan
         }
 
         [TestMethod]
+        public void GetMediaContentShouldReturnNullFor204Response()
+        {
+            var noContentResponse = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.NoContent,
+                Content = null,
+            };
+
+            Mock<HttpMessageHandler> handlerMock = Auth.Tests.Common.Http.SetupMockMessageHandler(noContentResponse);
+            var httpClient = new HttpClient(handlerMock.Object);
+
+            DocScanClient docScanClient = new DocScanClient(_sdkId, _keyPair, httpClient);
+
+            MediaValue mediaValue = docScanClient.GetMediaContent(_someSessionId, _someMediaId);
+
+            Assert.IsNull(mediaValue);
+        }
+
+        [TestMethod]
         public void GetSupportedDocumentShouldSucceed()
         {
             var passport = new SupportedDocument("PASSPORT");


### PR DESCRIPTION
-  Don't assume response always has content
  - for 204 (No content), return null instead (currently throws exception)