### PR TITLE
SDK-1997: Add Support for Mobile Handoff to IDV (Doc Scan)

### DIFF
--- a/src/Examples/DocScan/DocScanExample/Controllers/HomeController.cs
+++ b/src/Examples/DocScan/DocScanExample/Controllers/HomeController.cs
@@ -77,6 +77,7 @@ namespace DocScanExample.Controllers
                     .WithSuccessUrl(string.Join("/", _baseUrl, "idverify/success"))
                     .WithErrorUrl(string.Join("/", _baseUrl, "idverify/error"))
                     .WithPrivacyPolicyUrl(string.Join("/", _baseUrl, "privacy-policy"))
+                    .WithAllowHandoff(false)
                     .Build()
                     )
                 .WithRequiredDocument(

--- a/src/Yoti.Auth/DocScan/Session/Create/SdkConfig.cs
+++ b/src/Yoti.Auth/DocScan/Session/Create/SdkConfig.cs
@@ -34,6 +34,9 @@ namespace Yoti.Auth.DocScan.Session.Create
         [JsonProperty(PropertyName = "privacy_policy_url")]
         public string PrivacyPolicyUrl { get; }
 
+        [JsonProperty(PropertyName = "allow_handoff")]
+        public bool? AllowHandoff { get; }
+
         public SdkConfig(string allowedCaptureMethods,
                         string primaryColour,
                         string secondaryColour,
@@ -42,8 +45,9 @@ namespace Yoti.Auth.DocScan.Session.Create
                         string presetIssuingCountry,
                         string successUrl,
                         string errorUrl,
-                        string privacyPolicyUrl)
-        {
+                        string privacyPolicyUrl,
+                        bool? allowHandoff = null)
+        { 
             AllowedCaptureMethods = allowedCaptureMethods;
             PrimaryColour = primaryColour;
             SecondaryColour = secondaryColour;
@@ -53,6 +57,7 @@ namespace Yoti.Auth.DocScan.Session.Create
             SuccessUrl = successUrl;
             ErrorUrl = errorUrl;
             PrivacyPolicyUrl = privacyPolicyUrl;
+            AllowHandoff = allowHandoff;
         }
     }
 }

--- a/src/Yoti.Auth/DocScan/Session/Create/SdkConfigBuilder.cs
+++ b/src/Yoti.Auth/DocScan/Session/Create/SdkConfigBuilder.cs
@@ -13,6 +13,7 @@ namespace Yoti.Auth.DocScan.Session.Create
         private string _successUrl;
         private string _errorUrl;
         private string _privacyPolicyUrl;
+        private bool? _allowHandoff;
 
         /// <summary>
         /// Sets the allowed capture method to "CAMERA"
@@ -132,6 +133,25 @@ namespace Yoti.Auth.DocScan.Session.Create
         }
 
         /// <summary>
+        /// Sets if the user is allowed to perform mobile handoff
+        /// </summary>
+        /// <remarks>
+        ///     <para>
+        ///         Mobile handoff allows the user to start a session on their desktop device, and then switch to using their mobile to upload resources (generally due to better camera quality on mobile devices)
+        ///     </para>
+        ///     <para>
+        ///         Note: Passing this value will override any value set in the Yoti Connect backend (which itself takes precedence over any value in lists of configured organisations)   
+        ///     </para>
+        /// </remarks>
+        /// <param name="allowHandoff">If mobile handoff is allowed</param>
+        /// <returns>The <see cref="SdkConfigBuilder"/></returns>
+        public SdkConfigBuilder WithAllowHandoff(bool allowHandoff)
+        {
+            _allowHandoff = allowHandoff;
+            return this;
+        }
+
+        /// <summary>
         /// Builds the <see cref="SdkConfig"/> based on values supplied to the builder
         /// </summary>
         /// <returns>The built <see cref="SdkConfig"/></returns>
@@ -146,7 +166,8 @@ namespace Yoti.Auth.DocScan.Session.Create
                 _presetIssuingCountry,
                 _successUrl,
                 _errorUrl,
-                _privacyPolicyUrl);
+                _privacyPolicyUrl,
+                _allowHandoff);
         }
     }
 }

--- a/test/Yoti.Auth.Tests/DocScan/Session/Create/SdkConfigBuilderTests.cs
+++ b/test/Yoti.Auth.Tests/DocScan/Session/Create/SdkConfigBuilderTests.cs
@@ -121,7 +121,7 @@ namespace Yoti.Auth.Tests.DocScan.Session.Create
         [TestMethod]
         public void ShouldBuildWithPrivacyPolicyUrl()
         {
-            string privacyPolicyUrl = "https://yourdomain.com/some/privacy/policy";
+            string privacyPolicyUrl = "https://yourdomain.com/some/privacy-policy";
 
             SdkConfig sdkConfig =
              new SdkConfigBuilder()
@@ -142,6 +142,29 @@ namespace Yoti.Auth.Tests.DocScan.Session.Create
              .Build();
 
             Assert.AreEqual(error, sdkConfig.ErrorUrl);
+        }
+
+        [TestMethod]
+        public void ShouldBuildWithMobileHandoff()
+        {
+            bool mobileHandoff = true;
+
+            SdkConfig sdkConfig =
+             new SdkConfigBuilder()
+             .WithAllowHandoff(mobileHandoff)
+             .Build();
+
+            Assert.AreEqual(mobileHandoff, sdkConfig.AllowHandoff);
+        }
+
+        [TestMethod]
+        public void MobileHandoffShouldBeNullIfNotSet()
+        {
+            SdkConfig sdkConfig =
+             new SdkConfigBuilder()
+             .Build();
+
+            Assert.IsNull(sdkConfig.AllowHandoff);
         }
     }
 }


### PR DESCRIPTION
### Description

Mobile handoff allows the user to start a session on their 
desktop device, and then switch to using their mobile to upload 
resources (generally due to better camera quality on mobile devices). 

- Modify SdkConfig (non breaking change as new constructor 
parameter is default & optional)
- Modify SdkConfigBuilder with additional method to set this 
value to a bool

_Passing this value will override any value set in the Yoti Connect 
backend (which itself takes precedence over any value in lists of 
configured organisations)._

### Testing

Relevant Unit Tests added.