### PR TITLE
SDK-2003: Add Issuing Authority Sub Check to IDV

### DIFF
--- a/src/Yoti.Auth/DocScan/Session/Create/Check/IssuingAuthoritySubCheck.cs
+++ b/src/Yoti.Auth/DocScan/Session/Create/Check/IssuingAuthoritySubCheck.cs
@@ -1,0 +1,20 @@
+﻿using Newtonsoft.Json;
+using Yoti.Auth.DocScan.Session.Create.Filter;
+
+namespace Yoti.Auth.DocScan.Session.Create.Check
+{
+    public class IssuingAuthoritySubCheck
+    {
+        [JsonProperty(PropertyName = "requested")]
+        public bool Requested { get; }
+
+        [JsonProperty(PropertyName = "filter")]
+        public DocumentFilter Filter { get; }
+
+        public IssuingAuthoritySubCheck(bool requested, DocumentFilter filter = null)
+        {
+            Requested = requested;
+            Filter = filter;
+        }
+    }
+}

--- a/src/Yoti.Auth/DocScan/Session/Create/Check/IssuingAuthoritySubCheckBuilder.cs
+++ b/src/Yoti.Auth/DocScan/Session/Create/Check/IssuingAuthoritySubCheckBuilder.cs
@@ -1,0 +1,37 @@
+﻿using Yoti.Auth.DocScan.Session.Create.Filter;
+
+namespace Yoti.Auth.DocScan.Session.Create.Check
+{
+    public class IssuingAuthoritySubCheckBuilder
+    {
+        private bool _requested;
+        private DocumentFilter _filter;
+
+        /// <summary>
+        /// Sets whether the sub check will be requested for the Authenticity check.
+        /// </summary>
+        /// <param name="requested">If the sub check is requested</param>
+        /// <returns>The <see cref="IssuingAuthoritySubCheckBuilder"/></returns>
+        public IssuingAuthoritySubCheckBuilder WithRequested(bool requested)
+        {
+            _requested = requested;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the <see cref="DocumentFilter"/> that will be used to determine which documents the sub check is performed on.
+        /// </summary>
+        /// <param name="documentFilter">The <see cref="DocumentFilter"/> used to determine which documents the sub check is performed on</param>
+        /// <returns>The <see cref="IssuingAuthoritySubCheckBuilder"/></returns>
+        public IssuingAuthoritySubCheckBuilder WithFilter(DocumentFilter documentFilter)
+        {
+            _filter = documentFilter;
+            return this;
+        }
+
+        public IssuingAuthoritySubCheck Build()
+        {
+            return new IssuingAuthoritySubCheck(_requested, _filter);
+        }
+    }
+}

--- a/src/Yoti.Auth/DocScan/Session/Create/Check/RequestedDocumentAuthenticityCheckBuilder.cs
+++ b/src/Yoti.Auth/DocScan/Session/Create/Check/RequestedDocumentAuthenticityCheckBuilder.cs
@@ -1,8 +1,11 @@
-﻿namespace Yoti.Auth.DocScan.Session.Create.Check
+﻿using Yoti.Auth.DocScan.Session.Create.Filter;
+
+namespace Yoti.Auth.DocScan.Session.Create.Check
 {
     public class RequestedDocumentAuthenticityCheckBuilder
     {
         private string _manualCheck;
+        private IssuingAuthoritySubCheck _issuingAuthoritySubCheck;
 
         /// <summary>
         /// Requires that a manual follow-up check is always performed
@@ -34,9 +37,37 @@
             return this;
         }
 
+        /// <summary>
+        /// Adds an Issuing Authority Sub Check
+        /// </summary>
+        /// <returns>The <see cref="RequestedDocumentAuthenticityCheckBuilder"/></returns>
+        public RequestedDocumentAuthenticityCheckBuilder WithIssuingAuthoritySubCheck()
+        {
+            _issuingAuthoritySubCheck = new IssuingAuthoritySubCheckBuilder()
+                    .WithRequested(true)
+                    .Build();
+            return this;
+        }
+
+        /// <summary>
+        /// Adds an Issuing Authority Sub Check with a <see cref="DocumentFilter">documentFilter</see> (used to determine which documents the sub check is performed on).
+        /// </summary>
+        /// <param name="documentFilter">The <see cref="DocumentFilter"/> used to determine which documents the sub check is performed on</param>
+        /// <returns>The <see cref="RequestedDocumentAuthenticityCheckBuilder"/></returns>
+        public RequestedDocumentAuthenticityCheckBuilder WithIssuingAuthoritySubCheck(DocumentFilter documentFilter)
+        {
+            _issuingAuthoritySubCheck = new IssuingAuthoritySubCheckBuilder()
+                    .WithRequested(true)
+                    .WithFilter(documentFilter)
+                    .Build();
+            return this;
+        }
+
         public RequestedDocumentAuthenticityCheck Build()
         {
-            return new RequestedDocumentAuthenticityCheck(new RequestedDocumentAuthenticityConfig(_manualCheck));
+            var config = new RequestedDocumentAuthenticityConfig(_manualCheck, _issuingAuthoritySubCheck);
+
+            return new RequestedDocumentAuthenticityCheck(config);
         }
     }
 }

--- a/src/Yoti.Auth/DocScan/Session/Create/Check/RequestedDocumentAuthenticityConfig.cs
+++ b/src/Yoti.Auth/DocScan/Session/Create/Check/RequestedDocumentAuthenticityConfig.cs
@@ -7,9 +7,13 @@ namespace Yoti.Auth.DocScan.Session.Create.Check
         [JsonProperty(PropertyName = "manual_check")]
         public string ManualCheck { get; }
 
-        public RequestedDocumentAuthenticityConfig(string manualCheck)
+        [JsonProperty(PropertyName = "issuing_authority_sub_check")]
+        public IssuingAuthoritySubCheck IssuingAuthoritySubCheck { get; }
+
+        public RequestedDocumentAuthenticityConfig(string manualCheck, IssuingAuthoritySubCheck issuingAuthoritySubCheck = null)
         {
             ManualCheck = manualCheck;
+            IssuingAuthoritySubCheck = issuingAuthoritySubCheck;
         }
     }
 }

--- a/src/Yoti.Auth/DocScan/Session/Create/Filter/OrthogonalRestrictionsFilterBuilder.cs
+++ b/src/Yoti.Auth/DocScan/Session/Create/Filter/OrthogonalRestrictionsFilterBuilder.cs
@@ -30,7 +30,7 @@ namespace Yoti.Auth.DocScan.Session.Create.Filter
             _typeRestriction = new TypeRestriction(Constants.DocScanConstants.ExcludeList, documentTypes);
             return this;
         }
-
+        
         public OrthogonalRestrictionsFilter Build()
         {
             return new OrthogonalRestrictionsFilter(_countryRestriction, _typeRestriction);

--- a/test/Yoti.Auth.Tests/DocScan/Session/Create/Check/IssuingAuthoritySubCheckBuilderTests.cs
+++ b/test/Yoti.Auth.Tests/DocScan/Session/Create/Check/IssuingAuthoritySubCheckBuilderTests.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using Yoti.Auth.DocScan.Session.Create.Check;
+using Yoti.Auth.DocScan.Session.Create.Filter;
+
+namespace Yoti.Auth.Tests.DocScan.Session.Create.Check
+{
+    [TestClass]
+    public class IssuingAuthoritySubCheckBuilderTests
+    {
+        [DataTestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public void ShouldBuildWithCorrectRequestedValue(bool requested)
+        {
+            IssuingAuthoritySubCheck check =
+              new IssuingAuthoritySubCheckBuilder()
+              .WithRequested(requested)
+              .Build();
+
+            Assert.AreEqual(requested, check.Requested);
+        }
+
+        [TestMethod]
+        public void ShouldBuildWithCorrectFilterValue()
+        {
+            var filter = new OrthogonalRestrictionsFilterBuilder()
+                .WithIncludedCountries(new List<string> { "GBR", "FRA" })
+                .WithIncludedDocumentTypes(new List<string> { "PASSPORT", "STATE_ID" })
+                .Build();
+
+            IssuingAuthoritySubCheck check =
+              new IssuingAuthoritySubCheckBuilder()
+              .WithFilter(filter)
+              .Build();
+
+            Assert.AreEqual(filter, check.Filter);
+        }
+    }
+}

--- a/test/Yoti.Auth.Tests/DocScan/Session/Create/Check/RequestedDocumentAuthenticityCheckBuilderTests.cs
+++ b/test/Yoti.Auth.Tests/DocScan/Session/Create/Check/RequestedDocumentAuthenticityCheckBuilderTests.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
 using Yoti.Auth.DocScan.Session.Create.Check;
+using Yoti.Auth.DocScan.Session.Create.Filter;
 
 namespace Yoti.Auth.Tests.DocScan.Session.Create.Check
 {
@@ -37,6 +39,56 @@ namespace Yoti.Auth.Tests.DocScan.Session.Create.Check
               .Build();
 
             Assert.AreEqual("NEVER", check.Config.ManualCheck);
+        }
+
+        [TestMethod]
+        public void ShouldBuildWithIssuingAuthoritySubCheckToGiveDefaultObject()
+        {
+            RequestedDocumentAuthenticityCheck check =
+              new RequestedDocumentAuthenticityCheckBuilder()
+              .WithIssuingAuthoritySubCheck()
+              .Build();
+
+            Assert.IsTrue(check.Config.IssuingAuthoritySubCheck.Requested);
+            Assert.IsNull(check.Config.IssuingAuthoritySubCheck.Filter);
+        }
+
+        [TestMethod]
+        public void ShouldBuildWithIssuingAuthoritySubCheck()
+        {
+            var filter = new OrthogonalRestrictionsFilterBuilder()
+               .WithExcludedCountries(new List<string> { "GBR", "FRA" })
+               .WithExcludedDocumentTypes(new List<string> { "PASSPORT", "STATE_ID" })
+               .Build();
+
+            RequestedDocumentAuthenticityCheck check =
+              new RequestedDocumentAuthenticityCheckBuilder()
+              .WithIssuingAuthoritySubCheck(filter)
+              .Build();
+
+            Assert.IsTrue(check.Config.IssuingAuthoritySubCheck.Requested);
+            Assert.IsNotNull(check.Config.IssuingAuthoritySubCheck.Filter);
+            Assert.AreEqual(filter, check.Config.IssuingAuthoritySubCheck.Filter);
+        }
+
+        [TestMethod]
+        public void ShouldBuildWithIssuingAuthoritySubCheckVariation()
+        {
+            var filter = new DocumentRestrictionsFilterBuilder()
+                      .ForIncludeList()
+                      .WithDocumentRestriction(
+                          new List<string> { "USA" },
+                          new List<string> { "PASSPORT" })
+                      .Build();
+
+            RequestedDocumentAuthenticityCheck check =
+              new RequestedDocumentAuthenticityCheckBuilder()
+              .WithIssuingAuthoritySubCheck(filter)
+              .Build();
+
+            Assert.IsTrue(check.Config.IssuingAuthoritySubCheck.Requested);
+            Assert.IsNotNull(check.Config.IssuingAuthoritySubCheck.Filter);
+            Assert.AreEqual(filter, check.Config.IssuingAuthoritySubCheck.Filter);
         }
     }
 }

--- a/test/Yoti.Auth.Tests/DocScan/Session/Create/SessionSpecificationBuilderTests.cs
+++ b/test/Yoti.Auth.Tests/DocScan/Session/Create/SessionSpecificationBuilderTests.cs
@@ -112,7 +112,7 @@ namespace Yoti.Auth.Tests.DocScan.Session.Create
         }
 
         [TestMethod]
-        public void ShouldBuildWithWithRequiredDocument()
+        public void ShouldBuildWithRequiredDocument() 
         {
             SessionSpecification sessionSpec =
               new SessionSpecificationBuilder()
@@ -140,7 +140,7 @@ namespace Yoti.Auth.Tests.DocScan.Session.Create
         }
 
         [TestMethod]
-        public void ShouldBuildWithWithBlockBiometricConsentTrue()
+        public void ShouldBuildWithBlockBiometricConsentTrue()
         {
             SessionSpecification sessionSpec =
               new SessionSpecificationBuilder()
@@ -151,7 +151,7 @@ namespace Yoti.Auth.Tests.DocScan.Session.Create
         }
 
         [TestMethod]
-        public void ShouldBuildWithWithBlockBiometricConsentFalse()
+        public void ShouldBuildWithBlockBiometricConsentFalse()
         {
             SessionSpecification sessionSpec =
               new SessionSpecificationBuilder()


### PR DESCRIPTION
### Description

Add support for performing an "Issuing Authority Sub-Check" in addition
to existing Document Authenticity checks.