### PR TITLE
SDK-1979:Add Session Deadline To IDV

### DIFF
--- a/src/Yoti.Auth/DocScan/Session/Create/SessionSpecification.cs
+++ b/src/Yoti.Auth/DocScan/Session/Create/SessionSpecification.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using Yoti.Auth.DocScan.Session.Create.Check;
 using Yoti.Auth.DocScan.Session.Create.Filter;
@@ -8,7 +9,7 @@ namespace Yoti.Auth.DocScan.Session.Create
 {
     public class SessionSpecification
     {
-        internal SessionSpecification(int clientSessionTokenTtl, int resourcesTtl, string userTrackingId, NotificationConfig notifications, List<BaseRequestedCheck> requestedChecks, List<BaseRequestedTask> requestedTasks, SdkConfig sdkConfig, List<RequiredDocument> requiredDocuments, bool? blockBiometricConsent)
+        internal SessionSpecification(int? clientSessionTokenTtl, int resourcesTtl, string userTrackingId, NotificationConfig notifications, List<BaseRequestedCheck> requestedChecks, List<BaseRequestedTask> requestedTasks, SdkConfig sdkConfig, List<RequiredDocument> requiredDocuments, bool? blockBiometricConsent, DateTimeOffset? sessionDeadline)
         {
             ClientSessionTokenTtl = clientSessionTokenTtl;
             ResourcesTtl = resourcesTtl;
@@ -19,10 +20,11 @@ namespace Yoti.Auth.DocScan.Session.Create
             SdkConfig = sdkConfig;
             RequiredDocuments = requiredDocuments;
             BlockBiometricConsent = blockBiometricConsent;
+            SessionDeadline = sessionDeadline;
         }
 
         [JsonProperty(PropertyName = "client_session_token_ttl")]
-        public int ClientSessionTokenTtl { get; }
+        public int? ClientSessionTokenTtl { get; }
 
         [JsonProperty(PropertyName = "resources_ttl")]
         public int ResourcesTtl { get; }
@@ -47,5 +49,8 @@ namespace Yoti.Auth.DocScan.Session.Create
 
         [JsonProperty(PropertyName = "block_biometric_consent")]
         public bool? BlockBiometricConsent { get; }
+
+        [JsonProperty(PropertyName = "session_deadline")]
+        public DateTimeOffset? SessionDeadline { get; }
     }
 }

--- a/src/Yoti.Auth/DocScan/Session/Create/SessionSpecificationBuilder.cs
+++ b/src/Yoti.Auth/DocScan/Session/Create/SessionSpecificationBuilder.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Yoti.Auth.DocScan.Session.Create.Check;
 using Yoti.Auth.DocScan.Session.Create.Filter;
 using Yoti.Auth.DocScan.Session.Create.Task;
@@ -9,17 +10,21 @@ namespace Yoti.Auth.DocScan.Session.Create
     {
         private readonly List<BaseRequestedCheck> _requestedChecks = new List<BaseRequestedCheck>();
         private readonly List<BaseRequestedTask> _requestedTasks = new List<BaseRequestedTask>();
-        private int _clientSessionTokenTtl;
+        private int? _clientSessionTokenTtl;
         private int _resourcesTtl;
         private string _userTrackingId;
         private NotificationConfig _notifications;
         private SdkConfig _sdkConfig;
         private List<RequiredDocument> _requiredDocuments;
         private bool? _blockBiometricConsent;
+        private DateTimeOffset? _sessionDeadline;
 
         /// <summary>
         /// Sets the client session token TTL (time-to-live)
         /// </summary>
+        /// <remarks>
+        /// Can be used as an alternative to <see cref="WithSessionDeadline"/> 
+        /// </remarks>
         /// <param name="clientSessionTokenTtl">the client session token TTL</param>
         /// <returns>the builder</returns>
         public SessionSpecificationBuilder WithClientSessionTokenTtl(int clientSessionTokenTtl)
@@ -120,6 +125,20 @@ namespace Yoti.Auth.DocScan.Session.Create
         }
 
         /// <summary>
+        /// Sets the deadline that the session needs to be completed by
+        /// </summary>
+        /// <remarks>
+        /// Can be used as an alternative to <see cref="WithClientSessionTokenTtl"/> 
+        /// </remarks>
+        /// <param name="sessionDeadline">The <see cref="DateTimeOffset"/> for the session to end</param>
+        /// <returns>the builder</returns>
+        public SessionSpecificationBuilder WithSessionDeadline(DateTimeOffset sessionDeadline)
+        {
+            _sessionDeadline = sessionDeadline;
+            return this;
+        }
+
+        /// <summary>
         /// Builds the <see cref="SessionSpecification"/> based on the values supplied to the builder
         /// </summary>
         /// <returns>The built <see cref="SessionSpecification"/></returns>
@@ -134,7 +153,9 @@ namespace Yoti.Auth.DocScan.Session.Create
                 _requestedTasks,
                 _sdkConfig,
                 _requiredDocuments,
-                _blockBiometricConsent);
+                _blockBiometricConsent,
+                _sessionDeadline
+                );
         }
     }
 }

--- a/test/Yoti.Auth.Tests/DocScan/Session/Create/SessionSpecificationBuilderTests.cs
+++ b/test/Yoti.Auth.Tests/DocScan/Session/Create/SessionSpecificationBuilderTests.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
 using Yoti.Auth.DocScan.Session.Create;
 using Yoti.Auth.DocScan.Session.Create.Check;
 using Yoti.Auth.DocScan.Session.Create.Filter;
@@ -112,7 +114,7 @@ namespace Yoti.Auth.Tests.DocScan.Session.Create
         }
 
         [TestMethod]
-        public void ShouldBuildWithRequiredDocument() 
+        public void ShouldBuildWithRequiredDocument()
         {
             SessionSpecification sessionSpec =
               new SessionSpecificationBuilder()
@@ -159,6 +161,57 @@ namespace Yoti.Auth.Tests.DocScan.Session.Create
               .Build();
 
             Assert.IsFalse((bool)sessionSpec.BlockBiometricConsent);
+        }
+
+        [TestMethod]
+        public void ShouldBuildWithSessionDeadline()
+        {
+            var correctFormat = "2021-09-14T17:48:26.902+01:00";
+            DateTimeOffset dateTimeOffset = DateTimeOffset.Parse(correctFormat);
+
+            SessionSpecification sessionSpec =
+                new SessionSpecificationBuilder()
+                .WithSessionDeadline(dateTimeOffset)
+                .Build();
+
+            Assert.AreEqual(dateTimeOffset, sessionSpec.SessionDeadline);
+        }
+
+        [TestMethod]
+        public void ShouldCorrectlySerialiseSessionDeadlineFormat()
+        {
+            var correctFormat = "2021-09-14T17:48:26.902+01:00";
+            DateTimeOffset dateTimeOffset = DateTimeOffset.Parse(correctFormat);
+            var correctKvp = $"\"session_deadline\":\"{correctFormat}\"";
+
+            SessionSpecification sessionSpec =
+                new SessionSpecificationBuilder()
+                .WithSessionDeadline(dateTimeOffset)
+                .Build();
+            string sessionSpecJson = JsonConvert.SerializeObject(sessionSpec);
+
+            Assert.AreEqual(dateTimeOffset, sessionSpec.SessionDeadline);
+            Assert.IsTrue(sessionSpecJson.Contains(correctKvp));
+        }
+
+        [TestMethod]
+        public void ShouldNotImplicitlySetAValueForSessionDeadline()
+        {
+            SessionSpecification sessionSpec =
+                new SessionSpecificationBuilder()
+                .Build();
+
+            Assert.IsNull(sessionSpec.SessionDeadline);
+        }
+
+        [TestMethod]
+        public void ShouldNotImplicitlySetAValueForClientSessionTokenTtl()
+        {
+            SessionSpecification sessionSpec =
+                new SessionSpecificationBuilder()
+                .Build();
+
+            Assert.IsNull(sessionSpec.ClientSessionTokenTtl);
         }
     }
 }


### PR DESCRIPTION
Add Session Deadline To IDV
Modify ClientSessionTokenTtl to make it nullable and so omitted when Relying Business has not set