### PR TITLE
IDV Fix Resources TTL

### DIFF
--- a/src/Yoti.Auth/DocScan/Session/Create/SessionSpecification.cs
+++ b/src/Yoti.Auth/DocScan/Session/Create/SessionSpecification.cs
@@ -9,7 +9,7 @@ namespace Yoti.Auth.DocScan.Session.Create
 {
     public class SessionSpecification
     {
-        internal SessionSpecification(int? clientSessionTokenTtl, int resourcesTtl, string userTrackingId, NotificationConfig notifications, List<BaseRequestedCheck> requestedChecks, List<BaseRequestedTask> requestedTasks, SdkConfig sdkConfig, List<RequiredDocument> requiredDocuments, bool? blockBiometricConsent, DateTimeOffset? sessionDeadline)
+        internal SessionSpecification(int? clientSessionTokenTtl, int? resourcesTtl, string userTrackingId, NotificationConfig notifications, List<BaseRequestedCheck> requestedChecks, List<BaseRequestedTask> requestedTasks, SdkConfig sdkConfig, List<RequiredDocument> requiredDocuments, bool? blockBiometricConsent, DateTimeOffset? sessionDeadline)
         {
             ClientSessionTokenTtl = clientSessionTokenTtl;
             ResourcesTtl = resourcesTtl;
@@ -27,7 +27,7 @@ namespace Yoti.Auth.DocScan.Session.Create
         public int? ClientSessionTokenTtl { get; }
 
         [JsonProperty(PropertyName = "resources_ttl")]
-        public int ResourcesTtl { get; }
+        public int? ResourcesTtl { get; }
 
         [JsonProperty(PropertyName = "user_tracking_id")]
         public string UserTrackingId { get; }

--- a/src/Yoti.Auth/DocScan/Session/Create/SessionSpecificationBuilder.cs
+++ b/src/Yoti.Auth/DocScan/Session/Create/SessionSpecificationBuilder.cs
@@ -11,7 +11,7 @@ namespace Yoti.Auth.DocScan.Session.Create
         private readonly List<BaseRequestedCheck> _requestedChecks = new List<BaseRequestedCheck>();
         private readonly List<BaseRequestedTask> _requestedTasks = new List<BaseRequestedTask>();
         private int? _clientSessionTokenTtl;
-        private int _resourcesTtl;
+        private int? _resourcesTtl;
         private string _userTrackingId;
         private NotificationConfig _notifications;
         private SdkConfig _sdkConfig;


### PR DESCRIPTION
As previously suggested by @echarrod the resources_ttl now needs to be omitted when not set.