### PR TITLE
SDK-2056: Add Identity Profile Report attribute

### DIFF
--- a/src/Yoti.Auth/Constants/UserProfile.cs
+++ b/src/Yoti.Auth/Constants/UserProfile.cs
@@ -17,5 +17,6 @@
         public const string DateOfBirthAttribute = "date_of_birth";
         public const string DocumentDetailsAttribute = "document_details";
         public const string DocumentImagesAttribute = "document_images";
+        public const string IdentityProfileReportAttribute = "identity_profile_report";
     }
 }

--- a/src/Yoti.Auth/Profile/YotiProfile.cs
+++ b/src/Yoti.Auth/Profile/YotiProfile.cs
@@ -183,6 +183,19 @@ namespace Yoti.Auth.Profile
         }
 
         /// <summary>
+        /// IdentityProfileReport represents the JSON object containing identity assertion and the
+        /// verification report. This will be null if not provided by Yoti.
+        /// </summary>
+        public YotiAttribute<Dictionary<string, JToken>> IdentityProfileReport
+        {
+            get
+            {
+                return GetAttributeByName<Dictionary<string, JToken>>(name: Constants.UserProfile.IdentityProfileReportAttribute);
+            }
+        }
+
+
+        /// <summary>
         /// Finds all the 'Age Over' and 'Age Under' derived attributes returned with the profile,
         /// and returns them wrapped in <see cref="AgeVerification"/> objects. Returns null if no
         /// matches were found.

--- a/test/Yoti.Auth.Tests/ActivityTests.cs
+++ b/test/Yoti.Auth.Tests/ActivityTests.cs
@@ -584,9 +584,8 @@ namespace Yoti.Auth.Tests
 
             _yotiProfile = TestTools.Profile.CreateUserProfileWithSingleAttribute<Dictionary<string, JToken>>(attribute);
 
-            Dictionary<string, JToken> structuredPostalAddress = _yotiProfile.IdentityProfileReport.GetValue();
-            AssertDictionaryValue("<signature provided here>", "proof", structuredPostalAddress);
-
+            Dictionary<string, JToken> identityProfileReport = _yotiProfile.IdentityProfileReport.GetValue();
+            AssertDictionaryValue("<signature provided here>", "proof", identityProfileReport);
         }
 
         [TestMethod]

--- a/test/Yoti.Auth.Tests/ActivityTests.cs
+++ b/test/Yoti.Auth.Tests/ActivityTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using Google.Protobuf;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Yoti.Auth.Attribute;
 using Yoti.Auth.Document;
@@ -562,6 +563,30 @@ namespace Yoti.Auth.Tests
 
             AssertImages.ContainsExpectedImage(actualDocumentImages, "image/jpeg", "38TVEH/9k=");
             AssertImages.ContainsExpectedImage(actualDocumentImages, "image/jpeg", "vWgD//2Q==");
+        }
+
+
+        [TestMethod]
+        public void IdentityProfileReportAttributeShouldBeAddedToProfile()
+        {
+            string json;
+            using (StreamReader r = File.OpenText("TestData/RTWIdentityProfileReport.json"))
+            {
+                json = r.ReadToEnd();
+            }
+
+            var attribute = new ProtoBuf.Attribute.Attribute
+            {
+                Name = Constants.UserProfile.IdentityProfileReportAttribute,
+                ContentType = ContentType.Json,
+                Value = ByteString.CopyFromUtf8(json)
+            };
+
+            _yotiProfile = TestTools.Profile.CreateUserProfileWithSingleAttribute<Dictionary<string, JToken>>(attribute);
+
+            Dictionary<string, JToken> structuredPostalAddress = _yotiProfile.IdentityProfileReport.GetValue();
+            AssertDictionaryValue("<signature provided here>", "proof", structuredPostalAddress);
+
         }
 
         [TestMethod]

--- a/test/Yoti.Auth.Tests/TestData/RTWIdentityProfileReport.json
+++ b/test/Yoti.Auth.Tests/TestData/RTWIdentityProfileReport.json
@@ -1,0 +1,118 @@
+﻿{
+  "identity_assertion": {
+    "current_name": {
+      "given_names": "JOHN JIM FRED",
+      "first_name": "JOHN",
+      "middle_name": "JIM FRED",
+      "family_name": "FOO",
+      "full_name": "JOHN JIM FRED FOO"
+    },
+    "date_of_birth": "1979-01-01"
+  },
+  "verification_report": {
+    "report_id": "61b99534-116d-4a25-9750-2d708c0fb168",
+    "timestamp": "2022-01-02T15:04:05Z",
+    "subject_id": "f0726cb6-97c1-4802-9feb-eb7c6cd07949",
+    "trust_framework": "UK_TFIDA",
+    "schemes_compliance": [
+      {
+        "scheme": {
+          "type": "RTW"
+        },
+        "requirements_met": true
+      }
+    ],
+    "assurance_process": {
+      "level_of_assurance": "MEDIUM",
+      "policy": "GPG45",
+      "procedure": "M1C",
+      "assurance": [
+        {
+          "type": "EVIDENCE_STRENGTH",
+          "classification": "4",
+          "evidence_links": [
+            "41960172-ca91-487c-8bb3-2c547f80fe54"
+          ]
+        },
+        {
+          "type": "EVIDENCE_VALIDITY",
+          "classification": "3",
+          "evidence_links": [
+            "41960172-ca91-487c-8bb3-2c547f80fe54"
+          ]
+        },
+        {
+          "type": "VERIFICATION",
+          "classification": "3",
+          "evidence_links": [
+            "41960172-ca91-487c-8bb3-2c547f80fe54",
+            "fb0880ca-5dd5-4776-badb-17549123c50b"
+          ]
+        }
+      ]
+    },
+    "evidence": {
+      "documents": [
+        {
+          "evidence_id": "41960172-ca91-487c-8bb3-2c547f80fe54",
+          "timestamp": "2022-01-02T15:04:05Z",
+          "document_fields": {
+            "full_name": "JOHN JIM FRED FOO",
+            "date_of_birth": "1979-01-01",
+            "nationality": "GBR",
+            "given_names": "JOHN JIM FRED",
+            "family_name": "FOO",
+            "place_of_birth": "SAMPLETOWN",
+            "gender": "MALE",
+            "document_type": "PASSPORT",
+            "issuing_country": "GBR",
+            "document_number": "123456789",
+            "expiration_date": "2030-01-01",
+            "date_of_issue": "2020-01-01",
+            "issuing_authority": "HMPO",
+            "mrz": {
+              "type": 2,
+              "line1": "P<GBRFOO<<JOHN<JIM<FRED<<<<<<<<<<<<<<<<<<<<<",
+              "line2": "1234567892GBR7901018M3001215<<<<<<<<<<<<<<02"
+            }
+          },
+          "passed_checks": [
+            {
+              "check": "CHIP_DIGITAL_SIGNATURE"
+            },
+            {
+              "check": "AUTOMATED_FACE_MATCH"
+            },
+            {
+              "check": "FRAUD_DOCUMENTS_LIST"
+            }
+          ],
+          "verifying_org": "Yoti Ltd.",
+          "user_activity_ids": [
+            "d4764f67-2992-4a69-9ff4-55b0e77cb3d0"
+          ],
+          "document_images_attribute_id": "f253c8ab-f07b-4aeb-9dd0-50e670c7ebaf"
+        }
+      ],
+      "face_capture": {
+        "evidence_id": "fb0880ca-5dd5-4776-badb-17549123c50b",
+        "initial_liveness": {
+          "type": "ACTIVE",
+          "timestamp": "2022-01-02T15:04:05Z"
+        },
+        "verifying_org": "Yoti Ltd.",
+        "user_activity_ids": [
+          "a8e41187-7f5b-4e83-83d5-dc471452f1a8"
+        ],
+        "selfie_attribute_id": "cc507f84-f1aa-476a-877b-850e949e0fc8"
+      }
+    }
+  },
+  "authentication_report": {
+    "report_id": "d7202b65-657e-47a7-9679-7596db617b8c",
+    "timestamp": "2022-01-02T15:04:05Z",
+    "policy": "GPG44",
+    "level": "MEDIUM"
+  },
+  "proof": "<signature provided here>"
+}

--- a/test/Yoti.Auth.Tests/Yoti.Auth.Tests.csproj
+++ b/test/Yoti.Auth.Tests/Yoti.Auth.Tests.csproj
@@ -43,6 +43,9 @@
     <None Update="test-key-invalid-format.pem">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="TestData\RTWIdentityProfileReport.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="TestData\DynamicPolicy.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
### Added
- Identity Profile Report attribute (type JSON)
  - See [RTWIdentityProfileReport.json](https://github.com/getyoti/yoti-dotnet-sdk/blob/776f4e852cb3ab50fa1251952940b039686fcdd0/test/Yoti.Auth.Tests/TestData/RTWIdentityProfileReport.json) for an example of the JSON value