### PR TITLE
SDK-1150: Fix FindAttributesStartingWith for Derived Attributes 

### DIFF
--- a/src/Yoti.Auth/Profile/BaseProfile.cs
+++ b/src/Yoti.Auth/Profile/BaseProfile.cs
@@ -131,12 +131,17 @@ namespace Yoti.Auth.Profile
 
             List<YotiAttribute<T>> matches = new List<YotiAttribute<T>>();
 
-            foreach (KeyValuePair<string, List<BaseAttribute>> attribute in _attributes)
+            foreach (KeyValuePair<string, List<BaseAttribute>> attributesByName in _attributes)
             {
-                if (attribute.Key.StartsWith(prefix, System.StringComparison.Ordinal)
-                    && attribute.Value is YotiAttribute<T> castableAttribute)
+                if (attributesByName.Key.StartsWith(prefix, StringComparison.Ordinal))
                 {
-                    matches.Add(castableAttribute);
+                    foreach (var attribute in attributesByName.Value)
+                    {
+                        if (attribute is YotiAttribute<T> castableAttribute)
+                        {
+                            matches.Add(castableAttribute);
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
### Fixed 
- Update FindAttributesStartingWith to loop through each attribute with the same name, after AttributeCollection was added in https://github.com/getyoti/yoti-dotnet-sdk/pull/122

We can't unit test this for this specific scenario as the logic is from the Age Over/Under attribute being derived before the attribute list is shared. This is covered in integration tests though