### PR TITLE
SDK-2096: Add IDV Identity Profile

### DIFF
--- a/src/Yoti.Auth/DocScan/Session/Retrieve/GetSessionResult.cs
+++ b/src/Yoti.Auth/DocScan/Session/Retrieve/GetSessionResult.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
 using Yoti.Auth.DocScan.Session.Retrieve.Check;
+using Yoti.Auth.DocScan.Session.Retrieve.IdentityProfile;
 using Yoti.Auth.DocScan.Session.Retrieve.Resource;
 
 namespace Yoti.Auth.DocScan.Session.Retrieve
@@ -47,6 +48,9 @@ namespace Yoti.Auth.DocScan.Session.Retrieve
 
         [JsonProperty(PropertyName = "biometric_consent")]
         public DateTime? BiometricConsentTimestamp { get; internal set; }
+
+        [JsonProperty(PropertyName = "identity_profile")]
+        public IdentityProfileResponse IdentityProfile { get; internal set; }
 
         public List<AuthenticityCheckResponse> GetAuthenticityChecks()
         {

--- a/src/Yoti.Auth/DocScan/Session/Retrieve/IdentityProfile/FailureReasonResponse.cs
+++ b/src/Yoti.Auth/DocScan/Session/Retrieve/IdentityProfile/FailureReasonResponse.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace Yoti.Auth.DocScan.Session.Retrieve.IdentityProfile
+{
+    public class FailureReasonResponse
+    {
+        [JsonProperty(PropertyName = "reason_code")]
+        public  string ReasonCode { get; private set; }
+    }
+}

--- a/src/Yoti.Auth/DocScan/Session/Retrieve/IdentityProfile/IdentityProfileResponse.cs
+++ b/src/Yoti.Auth/DocScan/Session/Retrieve/IdentityProfile/IdentityProfileResponse.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+
+namespace Yoti.Auth.DocScan.Session.Retrieve.IdentityProfile
+{
+    public class IdentityProfileResponse
+    {
+        [JsonProperty(PropertyName = "subject_id")]
+        public string SubjectId { get; private set; }
+        [JsonProperty(PropertyName = "result")]
+        public string Result { get; private set; }
+        [JsonProperty(PropertyName = "failure_reason")]
+        public FailureReasonResponse FailureReason { get; private set; }
+        [JsonProperty(PropertyName = "identity_profile_report")]
+        public Dictionary<string, JToken> Report { get; private set; }
+
+    }
+}

--- a/test/Yoti.Auth.Tests/TestData/GetSessionResultWithIdentityProfile.json
+++ b/test/Yoti.Auth.Tests/TestData/GetSessionResultWithIdentityProfile.json
@@ -1,0 +1,34 @@
+﻿{
+  "session_id": "a1746488-efcc-4c59-bd28-f849dcb933a2",
+  "client_session_token_ttl": 599,
+  "user_tracking_id": "user-tracking-id",
+  "biometric_consent": "2022-03-29T11:39:08.473Z",
+  "state": "COMPLETED",
+  "client_session_token": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "identity_profile": {
+    "subject_id": "someStringHere",
+    "result": "DONE",
+    "failure_reason": {
+      "reason_code": "MANDATORY_DOCUMENT_COULD_NOT_BE_PROVIDED"
+    },
+    "identity_profile_report": {
+      "trust_framework": "UK_TFIDA",
+      "schemes_compliance": [
+        {
+          "scheme": {
+            "type": "DBS",
+            "objective": "STANDARD"
+          },
+          "requirements_met": true,
+          "requirements_not_met_info": "some string here"
+        }
+      ],
+      "media": {
+        "id": "c69ff2db-6caf-4e74-8386-037711bbc8d7",
+        "type": "IMAGE",
+        "created": "2022-03-29T11:39:24Z",
+        "last_updated": "2022-03-29T11:39:24Z"
+      }
+    }
+  }
+}

--- a/test/Yoti.Auth.Tests/Yoti.Auth.Tests.csproj
+++ b/test/Yoti.Auth.Tests/Yoti.Auth.Tests.csproj
@@ -43,6 +43,9 @@
     <None Update="test-key-invalid-format.pem">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="TestData\GetSessionResultWithIdentityProfile.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="TestData\RTWIdentityProfileReport.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
### Added
- IdentityProfile to IDV GetSessionResult:
```csharp
IdentityProfileResponse identityProfile = getSessionResult.IdentityProfile;
string subjectId = identityProfile.SubjectId;
string result = identityProfile.Result;
string failureReasonCode = identityProfile.FailureReason.ReasonCode;
```
example IdentityProfile.Report value:
```json
"trust_framework": "UK_TFIDA",
"schemes_compliance": [{
		"scheme": {
			"type": "DBS",
			"objective": "STANDARD"
		},
		"requirements_met": true,
		"requirements_not_met_info": "info here"
	}
],
"media": {
	"id": "c69ff2db-6caf-4e74-8386-037711bbc8d7",
	"type": "IMAGE",
	"created": "2022-03-29T11:39:24Z",
	"last_updated": "2022-03-29T11:39:24Z"
}
```
MediaID can be retrieved with:
```csharp
string mediaId = getSessionResult.IdentityProfile.Report["media"]["id"]
```
and used to retrieve the full identity profile report as JSON with a separate call:
```csharp
MediaValue mediaValue = docScanClient.GetMediaContent("your-session-id", mediaId);
```
