### PR TITLE
NA: Fix Sonar code smell

### DIFF
--- a/src/Yoti.Auth/Profile/BaseProfile.cs
+++ b/src/Yoti.Auth/Profile/BaseProfile.cs
@@ -150,14 +150,10 @@ namespace Yoti.Auth.Profile
         {
             if (prefix == null)
                 throw new ArgumentNullException(nameof(prefix));
-            return 
-                _attributes.Where(
-                    attributesByName => attributesByName.Key.StartsWith(
-                        prefix, StringComparison.Ordinal))
-                .SelectMany(
-                    attributesByName => attributesByName.Value.Select(
-                    attribute => attribute as YotiAttribute<T>))
-                .ToList();
+            return _attributes
+                .Where(a => a.Key.StartsWith(prefix, StringComparison.Ordinal))
+                .SelectMany(at => at.Value.Where(ya => ya is YotiAttribute<T>)
+                .Select(yac => yac as YotiAttribute<T>)).ToList();
         }
     }
 }

--- a/src/Yoti.Auth/Profile/BaseProfile.cs
+++ b/src/Yoti.Auth/Profile/BaseProfile.cs
@@ -150,24 +150,14 @@ namespace Yoti.Auth.Profile
         {
             if (prefix == null)
                 throw new ArgumentNullException(nameof(prefix));
-
-            List<YotiAttribute<T>> matches = new List<YotiAttribute<T>>();
-
-            foreach (KeyValuePair<string, List<BaseAttribute>> attributesByName in _attributes)
-            {
-                if (attributesByName.Key.StartsWith(prefix, StringComparison.Ordinal))
-                {
-                    foreach (var attribute in attributesByName.Value)
-                    {
-                        if (attribute is YotiAttribute<T> castableAttribute)
-                        {
-                            matches.Add(castableAttribute);
-                        }
-                    }
-                }
-            }
-
-            return matches;
+            return 
+                _attributes.Where(
+                    attributesByName => attributesByName.Key.StartsWith(
+                        prefix, StringComparison.Ordinal))
+                .SelectMany(
+                    attributesByName => attributesByName.Value.Select(
+                    attribute => attribute as YotiAttribute<T>))
+                .ToList();
         }
     }
 }

--- a/src/Yoti.Auth/Profile/BaseProfile.cs
+++ b/src/Yoti.Auth/Profile/BaseProfile.cs
@@ -150,10 +150,10 @@ namespace Yoti.Auth.Profile
         {
             if (prefix == null)
                 throw new ArgumentNullException(nameof(prefix));
-            return _attributes
-                .Where(a => a.Key.StartsWith(prefix, StringComparison.Ordinal))
-                .SelectMany(at => at.Value.Where(ya => ya is YotiAttribute<T>)
-                .Select(yac => yac as YotiAttribute<T>)).ToList();
+
+            return _attributes.Where(a => a.Key.StartsWith(prefix, StringComparison.Ordinal))
+                .SelectMany(a => a.Value.OfType<YotiAttribute<T>>())
+                .ToList();
         }
     }
 }


### PR DESCRIPTION
### Changed
- Missed a code smell in https://github.com/getyoti/yoti-dotnet-sdk/pull/362

"SonarQube: Loops should be simplified with "LINQ" expressions"
> When a loop is filtering, selecting or aggregating, those functions can be handled with a clearer, more concise LINQ expression instead.

I've run the integration tests against this branch to check it doesn't modify behaviour