### PR TITLE
SDK-2140: Add ErrorCode and ResponseContent to YotiProfileException

### DIFF
--- a/src/Yoti.Auth/ActivityDetailsParser.cs
+++ b/src/Yoti.Auth/ActivityDetailsParser.cs
@@ -29,8 +29,8 @@ namespace Yoti.Auth
             }
             else if (parsedResponse.Receipt.SharingOutcome != "SUCCESS")
             {
-                throw new YotiProfileException(
-                    $"The share was not successful, sharing_outcome: '{parsedResponse.Receipt.SharingOutcome}'");
+                throw new YotiProfileException(@$"The share was not successful, sharing_outcome: '{parsedResponse.Receipt.SharingOutcome}'
+, there may be more info in '{nameof(YotiProfileException.ErrorCode)}' or '{nameof(YotiProfileException.ResponseContent)}'", responseContent);
             }
 
             ReceiptDO receipt = parsedResponse.Receipt;

--- a/src/Yoti.Auth/Exceptions/YotiProfileException.cs
+++ b/src/Yoti.Auth/Exceptions/YotiProfileException.cs
@@ -1,22 +1,35 @@
-﻿using System;
+﻿using Newtonsoft.Json.Linq;
+using System;
 
 namespace Yoti.Auth.Exceptions
 {
-    public class YotiProfileException : YotiException
-    {
-        public YotiProfileException()
-            : base()
-        {
-        }
+	public class YotiProfileException : YotiException
+	{
+		public YotiProfileException()
+			: base()
+		{
+		}
 
-        public YotiProfileException(string message)
-            : base(message)
-        {
-        }
+		public YotiProfileException(string message)
+			: base(message)
+		{
+		}
 
-        public YotiProfileException(string message, Exception innerException)
-            : base(message, innerException)
-        {
-        }
-    }
+		public YotiProfileException(string message, string responseContent)
+		 : base(message)
+		{
+			ResponseContent = responseContent;
+			dynamic jsonResponse = JObject.Parse(responseContent);
+			if (jsonResponse.error_details != null && jsonResponse.error_details.error_code != null)
+				ErrorCode = jsonResponse.error_details.error_code;
+		}
+
+		public YotiProfileException(string message, Exception innerException)
+			: base(message, innerException)
+		{
+		}
+
+		public string ResponseContent { get; private set; }
+		public string ErrorCode { get; private set; }
+	}
 }

--- a/src/Yoti.Auth/Yoti.Auth.csproj
+++ b/src/Yoti.Auth/Yoti.Auth.csproj
@@ -43,6 +43,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NLog" Version="4.7.15" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.5" />

--- a/test/Yoti.Auth.Tests/TestData/ShareFailure.json
+++ b/test/Yoti.Auth.Tests/TestData/ShareFailure.json
@@ -1,0 +1,16 @@
+﻿{
+    "session_data": null,
+    "receipt": {
+        "receipt_id": null,
+        "other_party_profile_content": null,
+        "policy_uri": null,
+        "personal_key": null,
+        "remember_me_id": null,
+        "sharing_outcome": "FAILURE",
+        "timestamp": "2022-02-23T13:04:11Z"
+    },
+    "error_details": {
+        "error_code": "SOME_ERROR_CODE",
+        "description": "SOME_DESCRIPTION"
+    }
+}

--- a/test/Yoti.Auth.Tests/TestData/ShareFailureMinimal.json
+++ b/test/Yoti.Auth.Tests/TestData/ShareFailureMinimal.json
@@ -1,0 +1,6 @@
+﻿{
+    "receipt": {
+        "sharing_outcome": "NOT_EQUAL_TO_SUCCESS"
+    },
+    "some_other_key": "SOME_OTHER_VALUE"
+}

--- a/test/Yoti.Auth.Tests/TestData/ShareFailureMissingErrorCode.json
+++ b/test/Yoti.Auth.Tests/TestData/ShareFailureMissingErrorCode.json
@@ -1,0 +1,15 @@
+﻿{
+    "session_data": null,
+    "receipt": {
+        "receipt_id": null,
+        "other_party_profile_content": null,
+        "policy_uri": null,
+        "personal_key": null,
+        "remember_me_id": null,
+        "sharing_outcome": "FAILURE",
+        "timestamp": "2022-02-23T13:04:11Z"
+    },
+    "error_details": {
+        "description": "SOME_DESCRIPTION"
+    }
+}

--- a/test/Yoti.Auth.Tests/TestData/ShareFailureMissingErrorDetails.json
+++ b/test/Yoti.Auth.Tests/TestData/ShareFailureMissingErrorDetails.json
@@ -1,0 +1,12 @@
+﻿{
+    "session_data": null,
+    "receipt": {
+        "receipt_id": null,
+        "other_party_profile_content": null,
+        "policy_uri": null,
+        "personal_key": null,
+        "remember_me_id": null,
+        "sharing_outcome": "FAILURE",
+        "timestamp": "2022-02-23T13:04:11Z"
+    }
+}

--- a/test/Yoti.Auth.Tests/Yoti.Auth.Tests.csproj
+++ b/test/Yoti.Auth.Tests/Yoti.Auth.Tests.csproj
@@ -43,6 +43,18 @@
     <None Update="test-key-invalid-format.pem">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="TestData\ShareFailureMinimal.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TestData\ShareFailureMissingErrorCode.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TestData\ShareFailureMissingErrorDetails.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TestData\ShareFailure.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="TestData\GetSessionResultWithIdentityProfile.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/test/Yoti.Auth.Tests/YotiClientEngineTests.cs
+++ b/test/Yoti.Auth.Tests/YotiClientEngineTests.cs
@@ -56,6 +56,98 @@ namespace Yoti.Auth.Tests
         }
 
         [TestMethod]
+        public void SharingFailureWithErrorCodeShouldThrowExceptionWithErrorCode()
+        {
+            string jsonResponse = System.IO.File.ReadAllText("TestData/ShareFailure.json");
+
+            Mock<HttpMessageHandler> handlerMock = SetupMockMessageHandler(
+                HttpStatusCode.OK, jsonResponse);
+                
+            var engine = new YotiClientEngine(new HttpClient(handlerMock.Object));
+
+            var profileException = Assert.ThrowsExceptionAsync<YotiProfileException>(async () =>
+            {
+                await engine.GetActivityDetailsAsync(EncryptedToken, SdkId, _keyPair, new Uri(Constants.Api.DefaultYotiApiUrl));
+            }).Result;
+
+            Assert.IsTrue(profileException.Message.StartsWith("The share was not successful"));
+            Assert.AreEqual(profileException.ErrorCode, "SOME_ERROR_CODE");
+        }
+
+        [TestMethod]
+        public void SharingFailureShouldThrowExceptionWithWholeResponseExposed()
+        {
+            string jsonResponse = System.IO.File.ReadAllText("TestData/ShareFailure.json");
+
+            Mock<HttpMessageHandler> handlerMock = SetupMockMessageHandler(
+                HttpStatusCode.OK, jsonResponse);
+
+            var engine = new YotiClientEngine(new HttpClient(handlerMock.Object));
+
+            var profileException = Assert.ThrowsExceptionAsync<YotiProfileException>(async () =>
+            {
+                await engine.GetActivityDetailsAsync(EncryptedToken, SdkId, _keyPair, new Uri(Constants.Api.DefaultYotiApiUrl));
+            }).Result;
+
+            Assert.IsTrue(profileException.Message.StartsWith("The share was not successful"));
+            Assert.AreEqual(profileException.ErrorCode, "SOME_ERROR_CODE");
+            Assert.AreEqual(profileException.ResponseContent, jsonResponse);
+        }
+
+        [TestMethod]
+        public void SharingFailureShouldThrowExceptionWithWholeResponseExposedRegardlessOfFormOfJson()
+        {
+            string jsonResponse = System.IO.File.ReadAllText("TestData/ShareFailureMinimal.json");
+
+            Mock<HttpMessageHandler> handlerMock = SetupMockMessageHandler(
+               HttpStatusCode.OK, jsonResponse);
+
+            var engine = new YotiClientEngine(new HttpClient(handlerMock.Object));
+
+            var profileException = Assert.ThrowsExceptionAsync<YotiProfileException>(async () =>
+            {
+                await engine.GetActivityDetailsAsync(EncryptedToken, SdkId, _keyPair, new Uri(Constants.Api.DefaultYotiApiUrl));
+            }).Result;
+
+            Assert.IsTrue(profileException.Message.StartsWith("The share was not successful"));
+            Assert.AreEqual(profileException.ErrorCode, default(string));
+            Assert.AreEqual(profileException.ResponseContent, jsonResponse); 
+        }
+
+        [TestMethod]
+        public void SharingFailureExceptionShouldExposeResponseContentRegardlessOfFormOfJson()
+        {
+            string jsonResponse = System.IO.File.ReadAllText("TestData/ShareFailureMinimal.json");
+
+            YotiProfileException profileException = new YotiProfileException("msg", jsonResponse);
+
+            Assert.AreEqual(profileException.ErrorCode, default(string));
+            Assert.AreEqual(profileException.ResponseContent, jsonResponse);
+        }
+
+        [TestMethod]
+        public void SharingFailureExceptionShouldExposeResponseContentRegardlessOfFormOfJson_MissingErrorDetails()
+        {
+            string jsonResponse = System.IO.File.ReadAllText("TestData/ShareFailureMissingErrorDetails.json");
+
+            YotiProfileException profileException = new YotiProfileException("msg", jsonResponse);
+
+            Assert.AreEqual(profileException.ErrorCode, default(string));
+            Assert.AreEqual(profileException.ResponseContent, jsonResponse);
+        }
+
+        [TestMethod]
+        public void SharingFailureExceptionShouldExposeResponseContentRegardlessOfFormOfJson_MissingErrorCode()
+        {
+            string jsonResponse = System.IO.File.ReadAllText("TestData/ShareFailureMissingErrorCode.json");
+
+            YotiProfileException profileException = new YotiProfileException("msg", jsonResponse);
+
+            Assert.AreEqual(profileException.ErrorCode, default(string));
+            Assert.AreEqual(profileException.ResponseContent, jsonResponse);
+        }
+
+        [TestMethod]
         public void NullReceiptShouldThrowException()
         {
             Mock<HttpMessageHandler> handlerMock = SetupMockMessageHandler(


### PR DESCRIPTION
to surface error details for failure receipts for Digital ID App Shares
