### PR TITLE
SDK-2201:Added fetch support

### DIFF
--- a/src/Examples/DocScan/DocScanExample/Controllers/DbsController.cs
+++ b/src/Examples/DocScan/DocScanExample/Controllers/DbsController.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Net.Http;
+using DocScanExample.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Yoti.Auth;
+using Yoti.Auth.DocScan;
+using Yoti.Auth.DocScan.Session.Create;
+using Yoti.Auth.DocScan.Session.Create.Check;
+using Yoti.Auth.DocScan.Session.Create.Filter;
+using Yoti.Auth.DocScan.Session.Create.Objectives;
+using Yoti.Auth.DocScan.Session.Create.Task;
+ 
+namespace DocScanExample.Controllers
+{
+    public class DbsController : Controller
+    {
+        private readonly DocScanClient _client;
+
+        private readonly string _baseUrl;
+        private readonly Uri _apiUrl;
+
+        public DbsController(IHttpContextAccessor httpContextAccessor)
+        {
+            var request = httpContextAccessor.HttpContext.Request;
+            
+            _baseUrl = $"{request.Scheme}://{request.Host}"; ;
+            _apiUrl = GetApiUrl();
+            _client = GetDocScanClient(_apiUrl);
+        }
+
+        public IActionResult Index()
+        {
+
+            //Build Session Spec
+            var sessionSpec = new SessionSpecificationBuilder()
+                .WithClientSessionTokenTtl(600)
+                .WithResourcesTtl(90000)
+                .WithUserTrackingId("some-user-tracking-id")
+                //Add Sdk Config (with builder)
+                .WithSdkConfig(
+                    new SdkConfigBuilder()
+                    .WithAllowsCameraAndUpload()
+                    .WithPrimaryColour("#2d9fff")
+                    .WithSecondaryColour("#FFFFFF")
+                    .WithFontColour("#FFFFFF")
+                    .WithLocale("en-GB")
+                    .WithPresetIssuingCountry("GBR")
+                    .WithSuccessUrl($"{_baseUrl}/idverify/success")
+                    .WithErrorUrl($"{_baseUrl}/idverify/error")
+                    .WithPrivacyPolicyUrl($"{_baseUrl}/privacy-policy")
+                    .Build()
+                    )
+                .WithCreateIdentityProfilePreview(true)
+                 .WithIdentityProfileRequirements(new
+                 {
+                     trust_framework = "UK_TFIDA",
+                     scheme = new
+                     {
+                         type = "DBS",
+                         objective = "BASIC"
+                     }
+                 })
+                .WithSubject(new
+                {
+                    subject_id = "some_subject_id_string"
+                })    
+            .Build();
+
+            CreateSessionResult createSessionResult = _client.CreateSession(sessionSpec);
+            string sessionId = createSessionResult.SessionId;
+           
+            string path = $"web/index.html?sessionID={sessionId}&sessionToken={createSessionResult.ClientSessionToken}";
+            Uri uri = new Uri(_apiUrl, path);
+
+            ViewBag.iframeUrl = uri.ToString();
+
+            TempData["sessionId"] = sessionId;
+            return View();
+        }
+
+        public IActionResult Media(string mediaId, string sessionId)
+        {
+            MediaValue media = _client.GetMediaContent(sessionId, mediaId);
+
+            return File(media.GetContent(), media.GetMIMEType());
+        }
+
+        [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
+        public IActionResult Error()
+        {
+            return View(new ErrorViewModel { RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier });
+        }
+
+        internal static DocScanClient GetDocScanClient(Uri apiUrl = null)
+        {
+            if (apiUrl == null)
+                apiUrl = GetApiUrl();
+
+            StreamReader privateKeyStream = System.IO.File.OpenText(Environment.GetEnvironmentVariable("YOTI_KEY_FILE_PATH"));
+            var key = CryptoEngine.LoadRsaKey(privateKeyStream);
+
+            string clientSdkId = Environment.GetEnvironmentVariable("YOTI_CLIENT_SDK_ID");
+
+            return new DocScanClient(clientSdkId, key, new HttpClient(), apiUrl);
+        }
+
+        internal static Uri GetApiUrl()
+        {
+            string apiUrl = Environment.GetEnvironmentVariable("YOTI_DOC_SCAN_API_URL");
+            if (string.IsNullOrEmpty(apiUrl))
+            {
+                return Yoti.Auth.Constants.Api.DefaultYotiDocsUrl;
+            }
+
+            if (!apiUrl.EndsWith("/", StringComparison.Ordinal))
+                apiUrl += "/";
+
+            return new Uri(apiUrl);
+        }
+
+        public IActionResult PrivacyPolicy()
+        {
+            return View();
+        }
+    }
+}

--- a/src/Examples/DocScan/DocScanExample/DocScanExample.csproj
+++ b/src/Examples/DocScan/DocScanExample/DocScanExample.csproj
@@ -12,4 +12,10 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\Yoti.Auth\Yoti.Auth.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <None Remove="Views\Dbs\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Views\Dbs\" />
+  </ItemGroup>
 </Project>

--- a/src/Examples/DocScan/DocScanExample/Views/Dbs/Index.cshtml
+++ b/src/Examples/DocScan/DocScanExample/Views/Dbs/Index.cshtml
@@ -1,0 +1,4 @@
+﻿@{
+    ViewData["Title"] = "Dbs Page";
+}
+<iframe style="border:none;" width="100%" height="750" allow="camera" src="@ViewBag.iframeUrl" allowfullscreen></iframe>

--- a/src/Examples/Profile/CoreExample/Controllers/HomeController.cs
+++ b/src/Examples/Profile/CoreExample/Controllers/HomeController.cs
@@ -109,7 +109,6 @@ namespace CoreExample.Controllers
                              objective = "BASIC"
                          }
                      })
-                    .WithCreateIdentityProfilePreview(true)
                     .Build();
 
                 var dynamicScenario = new DynamicScenarioBuilder()

--- a/src/Yoti.Auth/DocScan/Session/Create/SessionSpecification.cs
+++ b/src/Yoti.Auth/DocScan/Session/Create/SessionSpecification.cs
@@ -9,7 +9,7 @@ namespace Yoti.Auth.DocScan.Session.Create
 {
     public class SessionSpecification
     {
-        internal SessionSpecification(int? clientSessionTokenTtl, int? resourcesTtl, string userTrackingId, NotificationConfig notifications, List<BaseRequestedCheck> requestedChecks, List<BaseRequestedTask> requestedTasks, SdkConfig sdkConfig, List<RequiredDocument> requiredDocuments, bool? blockBiometricConsent, DateTimeOffset? sessionDeadline, object identityProfileRequirements, object subject)
+        internal SessionSpecification(int? clientSessionTokenTtl, int? resourcesTtl, string userTrackingId, NotificationConfig notifications, List<BaseRequestedCheck> requestedChecks, List<BaseRequestedTask> requestedTasks, SdkConfig sdkConfig, List<RequiredDocument> requiredDocuments, bool? blockBiometricConsent, DateTimeOffset? sessionDeadline, object identityProfileRequirements, object subject, bool createIdentityProfilePreview)
         {
             ClientSessionTokenTtl = clientSessionTokenTtl;
             ResourcesTtl = resourcesTtl;
@@ -23,6 +23,7 @@ namespace Yoti.Auth.DocScan.Session.Create
             SessionDeadline = sessionDeadline;
             IdentityProfileRequirements = identityProfileRequirements;
             Subject = subject;
+            CreateIdentityProfilePreview = createIdentityProfilePreview;
         }
 
         [JsonProperty(PropertyName = "client_session_token_ttl")]
@@ -57,6 +58,9 @@ namespace Yoti.Auth.DocScan.Session.Create
 
         [JsonProperty(PropertyName = "identity_profile_requirements")]
         public object IdentityProfileRequirements { get; }
+
+        [JsonProperty(PropertyName = "create_identity_profile_preview")]
+        public readonly bool CreateIdentityProfilePreview;
 
         [JsonProperty(PropertyName = "subject")]
         public object Subject { get; }

--- a/src/Yoti.Auth/DocScan/Session/Create/SessionSpecificationBuilder.cs
+++ b/src/Yoti.Auth/DocScan/Session/Create/SessionSpecificationBuilder.cs
@@ -20,6 +20,7 @@ namespace Yoti.Auth.DocScan.Session.Create
         private DateTimeOffset? _sessionDeadline;
         private object _identityProfileRequirements;
         private object _subject;
+        private bool _createIdentityProfilePreview;
 
         /// <summary>
         /// Sets the client session token TTL (time-to-live)
@@ -163,6 +164,17 @@ namespace Yoti.Auth.DocScan.Session.Create
         }
 
         /// <summary>
+        /// Sets the Identity Profile Requirements for the session
+        /// </summary>
+        /// <param name="identityProfileRequirements">The Identity Profile Requirements <see cref="object"/> for the session</param>
+        /// <returns>the builder</returns>
+        public SessionSpecificationBuilder WithCreateIdentityProfilePreview(bool createIdentityProfilePreview)
+        {
+            _createIdentityProfilePreview = createIdentityProfilePreview;
+            return this;
+        }
+
+        /// <summary>
         /// Builds the <see cref="SessionSpecification"/> based on the values supplied to the builder
         /// </summary>
         /// <returns>The built <see cref="SessionSpecification"/></returns>
@@ -180,7 +192,8 @@ namespace Yoti.Auth.DocScan.Session.Create
                 _blockBiometricConsent,
                 _sessionDeadline,
                 _identityProfileRequirements,
-                _subject
+                _subject,
+                _createIdentityProfilePreview
                 );
         }
     }

--- a/src/Yoti.Auth/DocScan/Session/Retrieve/GetSessionResult.cs
+++ b/src/Yoti.Auth/DocScan/Session/Retrieve/GetSessionResult.cs
@@ -5,6 +5,7 @@ using Newtonsoft.Json;
 using Yoti.Auth.DocScan.Session.Retrieve.Check;
 using Yoti.Auth.DocScan.Session.Retrieve.IdentityProfile;
 using Yoti.Auth.DocScan.Session.Retrieve.Resource;
+using Yoti.Auth.DocScan.Session.Retrieve.IdentityProfilePreview;
 
 namespace Yoti.Auth.DocScan.Session.Retrieve
 {
@@ -51,6 +52,9 @@ namespace Yoti.Auth.DocScan.Session.Retrieve
 
         [JsonProperty(PropertyName = "identity_profile")]
         public IdentityProfileResponse IdentityProfile { get; internal set; }
+
+        [JsonProperty(PropertyName = "identity_profile_preview")]
+        public IdentityProfilePreviewResponse IdentityProfilePreviewResponse { get; internal set; }
 
         public List<AuthenticityCheckResponse> GetAuthenticityChecks()
         {

--- a/src/Yoti.Auth/DocScan/Session/Retrieve/IdentityProfile/IdentityProfilePreviewResponse.cs
+++ b/src/Yoti.Auth/DocScan/Session/Retrieve/IdentityProfile/IdentityProfilePreviewResponse.cs
@@ -1,0 +1,12 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+
+namespace Yoti.Auth.DocScan.Session.Retrieve.IdentityProfilePreview
+{
+    public class IdentityProfilePreviewResponse
+    {
+        [JsonProperty(PropertyName = "media")]
+        public MediaResponse Media { get; private set; }
+    }
+}

--- a/src/Yoti.Auth/ShareUrl/Policy/DynamicPolicy.cs
+++ b/src/Yoti.Auth/ShareUrl/Policy/DynamicPolicy.cs
@@ -30,22 +30,18 @@ namespace Yoti.Auth.ShareUrl.Policy
         [JsonProperty(PropertyName = "identity_profile_requirements")]
         private readonly object _identityProfileRequirements;
 
-        [JsonProperty(PropertyName = "create_identity_profile_preview")]
-        private readonly object _createIdentityProfilePreview;
-
         public DynamicPolicy(
                  ICollection<WantedAttribute> wantedAttributes,
                  HashSet<int> wantedAuthTypes,
                  bool wantedRememberMeId,
-                 object identityProfileRequirements = null,
-                 bool createIdentityProfilePreview = false)
+                 object identityProfileRequirements = null
+            )
         {
             _wantedAttributes = wantedAttributes;
             _wantedAuthTypes = wantedAuthTypes;
             _wantedRememberMeId = wantedRememberMeId;
             _isWantedRememberMeIdOptional = false;
             _identityProfileRequirements = identityProfileRequirements;
-            _createIdentityProfilePreview = createIdentityProfilePreview;
         }
 
         /// <summary>

--- a/src/Yoti.Auth/ShareUrl/Policy/DynamicPolicyBuilder.cs
+++ b/src/Yoti.Auth/ShareUrl/Policy/DynamicPolicyBuilder.cs
@@ -9,7 +9,6 @@ namespace Yoti.Auth.ShareUrl.Policy
         private readonly HashSet<int> _wantedAuthTypes = new HashSet<int>();
         private bool _wantedRememberMeId;
         private object _identityProfileRequirements;
-        private bool _createIdentityProfilePreview;
 
         public DynamicPolicyBuilder WithWantedAttribute(WantedAttribute wantedAttribute)
         {
@@ -159,20 +158,9 @@ namespace Yoti.Auth.ShareUrl.Policy
             return this;
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="createIdentityProfilePreview"> boolean value for setting createIdentityProfilePreview</param> 
-        /// <returns><see cref="DynamicPolicyBuilder"/> with the identity profile requirements</returns>
-        public DynamicPolicyBuilder WithCreateIdentityProfilePreview(bool createIdentityProfilePreview)
-        {
-            _createIdentityProfilePreview = createIdentityProfilePreview;
-            return this;
-        }
-
         public DynamicPolicy Build()
         {
-            return new DynamicPolicy(_wantedAttributes.Values, _wantedAuthTypes, _wantedRememberMeId, _identityProfileRequirements, _createIdentityProfilePreview);
+            return new DynamicPolicy(_wantedAttributes.Values, _wantedAuthTypes, _wantedRememberMeId, _identityProfileRequirements);
         }
     }
 }

--- a/test/Yoti.Auth.Tests/DocScan/Session/Create/SessionSpecificationBuilderTests.cs
+++ b/test/Yoti.Auth.Tests/DocScan/Session/Create/SessionSpecificationBuilderTests.cs
@@ -143,6 +143,51 @@ namespace Yoti.Auth.Tests.DocScan.Session.Create
         }
 
         [TestMethod]
+        public void ShoudBuildWithIdentityProfileRequirements()
+        {
+            var sessionSpec = new SessionSpecificationBuilder()
+                 .WithIdentityProfileRequirements(new
+                 {
+                     trust_framework = "UK_TFIDA",
+                     scheme = new
+                     {
+                         type = "DBS",
+                         objective = "BASIC"
+                     }
+                 })
+            .Build();
+
+            string sessionSpecJson = JsonConvert.SerializeObject(sessionSpec);
+            Assert.IsTrue(sessionSpecJson.Contains("UK_TFIDA"));
+            Assert.IsTrue(sessionSpecJson.Contains("DBS"));
+            Assert.IsTrue(sessionSpecJson.Contains("BASIC"));
+        }
+
+        [TestMethod]
+        public void ShoudBuildWithSubject()
+        {
+            var sessionSpec = new SessionSpecificationBuilder()
+                .WithSubject(new
+                {
+                    subject_id = "some_subject_id_string"
+                })
+            .Build();
+
+            string sessionSpecJson = JsonConvert.SerializeObject(sessionSpec);
+            Assert.IsTrue(sessionSpecJson.Contains("some_subject_id_string"));
+        }
+
+        [TestMethod]
+        public void ShoudBuildWithCreateIdentityProfilePreview()
+        {
+            var sessionSpec = new SessionSpecificationBuilder()
+                .WithCreateIdentityProfilePreview(true)
+            .Build();
+
+            Assert.IsTrue(sessionSpec.CreateIdentityProfilePreview);
+        }
+
+        [TestMethod]
         public void ShouldBuildWithBlockBiometricConsentTrue()
         {
             SessionSpecification sessionSpec =
@@ -163,6 +208,7 @@ namespace Yoti.Auth.Tests.DocScan.Session.Create
 
             Assert.IsFalse((bool)sessionSpec.BlockBiometricConsent);
         }
+
 
         [TestMethod]
         public void ShouldBuildWithSessionDeadline()
@@ -223,6 +269,20 @@ namespace Yoti.Auth.Tests.DocScan.Session.Create
             SessionSpecification sessionSpec =
                 new SessionSpecificationBuilder()
                 .WithIdentityProfileRequirements(identityProfileRequirements)
+                .Build();
+
+            Assert.AreEqual(identityProfileRequirements, sessionSpec.IdentityProfileRequirements);
+        }
+
+        [TestMethod]
+        public void ShouldBuildWithIdentityProfilePreview()
+        {
+            object identityProfileRequirements = IdentityProfiles.CreateStandardIdentityProfileRequirements();
+
+            SessionSpecification sessionSpec =
+                new SessionSpecificationBuilder()
+                .WithIdentityProfileRequirements(identityProfileRequirements)
+                .WithCreateIdentityProfilePreview(true)
                 .Build();
 
             Assert.AreEqual(identityProfileRequirements, sessionSpec.IdentityProfileRequirements);

--- a/test/Yoti.Auth.Tests/DocScan/Session/Retrieve/GetSessionResultTests.cs
+++ b/test/Yoti.Auth.Tests/DocScan/Session/Retrieve/GetSessionResultTests.cs
@@ -1,8 +1,11 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
 using Yoti.Auth.DocScan.Session.Retrieve;
 using Yoti.Auth.DocScan.Session.Retrieve.Check;
+using Yoti.Auth.DocScan.Session.Retrieve.IdentityProfilePreview;
 
 namespace Yoti.Auth.Tests.DocScan.Session.Retrieve
 {
@@ -327,6 +330,43 @@ namespace Yoti.Auth.Tests.DocScan.Session.Retrieve
 
             Assert.AreEqual(1, getSessionResult.GetWatchlistAdvancedCaChecks().Count);
             Assert.IsInstanceOfType(getSessionResult.GetWatchlistAdvancedCaChecks().First(), typeof(WatchlistAdvancedCaCheckResponse));
+        }
+
+        [TestMethod]
+        public void CheckIdentityProfilePreviewResponseIsParsed()
+        {
+            dynamic identityProfilePreviewResponse = new
+            {
+                 media = GetMediaResponse() 
+            };
+
+            string json = JsonConvert.SerializeObject(identityProfilePreviewResponse);
+            IdentityProfilePreviewResponse response =
+                JsonConvert.DeserializeObject<IdentityProfilePreviewResponse>(json);
+
+            AssertMediaValuesCorrect(identityProfilePreviewResponse.media, response.Media, typeof(MediaResponse));
+        }
+
+        private void AssertMediaValuesCorrect(dynamic originalData, MediaResponse response, Type requiredType)
+        {
+            Assert.AreEqual(originalData.id, response.Id);
+            Assert.AreEqual(originalData.type, response.Type);
+            Assert.AreEqual(originalData.created, response.Created);
+            Assert.AreEqual(originalData.last_updated, response.LastUpdated);
+            Assert.IsInstanceOfType(response, requiredType);
+        }
+
+        private dynamic GetMediaResponse()
+        {
+            DateTime now = DateTime.Now;
+            dynamic mediaResponse = new
+            {
+                id = "ca492333-35bf-4cc4-a87a-e4af67c30e67",
+                type = "IMAGE",
+                created = now.AddMinutes(-10),
+                last_updated = now.AddMinutes(-2)
+            };
+            return mediaResponse;
         }
 
         [TestMethod]

--- a/test/Yoti.Auth.Tests/TestData/DynamicPolicy.json
+++ b/test/Yoti.Auth.Tests/TestData/DynamicPolicy.json
@@ -31,8 +31,7 @@
         "type": "DBS",
         "objective": "STANDARD"
       }
-    },
-    "create_identity_profile_preview":true
+    }
   },
   "extensions": [
     {

--- a/test/Yoti.Auth.Tests/TestTools/ShareUrl.cs
+++ b/test/Yoti.Auth.Tests/TestTools/ShareUrl.cs
@@ -20,7 +20,6 @@ namespace Yoti.Auth.Tests.TestTools
               .WithAgeUnder(40)
               .WithPinAuthentication(true)
               .WithIdentityProfileRequirements(IdentityProfiles.CreateStandardIdentityProfileRequirements())
-              .WithCreateIdentityProfilePreview(true)
               .Build();
         }
     }


### PR DESCRIPTION
## IDV

**Added**

- Add support for requesting the profile preview
**Requested With**
```csharp
 //Build Session Spec
            var sessionSpec = new SessionSpecificationBuilder()
                .WithClientSessionTokenTtl(600)
                .WithResourcesTtl(90000)
                .WithUserTrackingId("some-user-tracking-id")
                //Add Sdk Config (with builder)
                .WithSdkConfig(
                    new SdkConfigBuilder()
                    .WithAllowsCameraAndUpload()
                    .WithPrimaryColour("#2d9fff")
                    .WithSecondaryColour("#FFFFFF")
                    .WithFontColour("#FFFFFF")
                    .WithLocale("en-GB")
                    .WithPresetIssuingCountry("GBR")
                    .WithSuccessUrl($"{_baseUrl}/idverify/success")
                    .WithErrorUrl($"{_baseUrl}/idverify/error")
                    .WithPrivacyPolicyUrl($"{_baseUrl}/privacy-policy")
                    .Build()
                    )
                .WithCreateIdentityProfilePreview(true)
                 .WithIdentityProfileRequirements(new
                 {
                     trust_framework = "UK_TFIDA",
                     scheme = new
                     {
                         type = "DBS",
                         objective = "BASIC"
                     }
                 })
                .WithSubject(new
                {
                    subject_id = "some_subject_id_string"
                })    
            .Build();
```