### PR TITLE
SDK-2713-net-sdk-request-header

### DIFF
--- a/src/Yoti.Auth/DigitalIdentityClient.cs
+++ b/src/Yoti.Auth/DigitalIdentityClient.cs
@@ -59,37 +59,50 @@ namespace Yoti.Auth
         }
         
         /// <summary>
-        /// Initiate a sharing process based on a <see cref="ShareSessionRequest"/>.
+        /// Initiate a sharing process based on a <see cref="ShareSessionRequest"/>. 
         /// </summary>
         /// <param name="shareSessionRequest">
         /// Details of the device's callback endpoint, <see
         /// cref="Yoti.Auth.DigitalIdentity.Policy"/> and extensions for the application
         /// </param>
-        /// <returns><see cref="ShareSessionResult"/></returns>
-        public ShareSessionResult CreateShareSession(ShareSessionRequest shareSessionRequest)
+        /// <returns>A YotiHttpResponse containing the ShareSessionResult and HTTP headers</returns>
+        public Web.YotiHttpResponse<ShareSessionResult> CreateShareSession(ShareSessionRequest shareSessionRequest)
         {
-            Task<ShareSessionResult> task = Task.Run(async () => await CreateShareSessionAsync(shareSessionRequest).ConfigureAwait(false));
+            Task<Web.YotiHttpResponse<ShareSessionResult>> task = Task.Run(async () => await CreateShareSessionAsync(shareSessionRequest).ConfigureAwait(false));
 
             return task.Result;
-        }
-
-        /// <summary>
+        }        /// <summary>
         /// Asynchronously initiate a sharing process based on a <see cref="ShareSessionRequest"/>.
         /// </summary>
         /// <param name="shareSessionRequest">
         /// Details of the device's callback endpoint, <see
         /// cref="Yoti.Auth.DigitalIdentity.Policy"/> and extensions for the application
         /// </param>
-        /// <returns><see cref="ShareSessionResult"/></returns>
-        public async Task<ShareSessionResult> CreateShareSessionAsync(ShareSessionRequest shareSessionRequest)
+        /// <returns>A YotiHttpResponse containing the ShareSessionResult and HTTP headers</returns>
+        public async Task<Web.YotiHttpResponse<ShareSessionResult>> CreateShareSessionAsync(ShareSessionRequest shareSessionRequest)
         {
-            return await _yotiDigitalClientEngine.CreateShareSessionAsync(_sdkId, _keyPair, ApiUri, shareSessionRequest).ConfigureAwait(false);
+            return await _yotiDigitalClientEngine.CreateShareSessionWithHeadersAsync(_sdkId, _keyPair, ApiUri, shareSessionRequest).ConfigureAwait(false);
         }
 
-        public SharedReceiptResponse GetShareReceipt(string receiptId)
+        /// <summary>
+        /// Gets a share receipt with HTTP response headers including X-Request-ID
+        /// </summary>
+        /// <param name="receiptId">The receipt ID to retrieve</param>
+        /// <returns>A YotiHttpResponse containing the SharedReceiptResponse and HTTP headers</returns>
+        public Web.YotiHttpResponse<SharedReceiptResponse> GetShareReceipt(string receiptId)
         {
-            Task<SharedReceiptResponse> task = Task.Run(async () => await _yotiDigitalClientEngine.GetShareReceipt(_sdkId, _keyPair, ApiUri, receiptId).ConfigureAwait(false));
+            Task<Web.YotiHttpResponse<SharedReceiptResponse>> task = Task.Run(async () => await GetShareReceiptAsync(receiptId).ConfigureAwait(false));
             return task.Result;
+        }
+
+        /// <summary>
+        /// Asynchronously gets a share receipt with HTTP response headers including X-Request-ID
+        /// </summary>
+        /// <param name="receiptId">The receipt ID to retrieve</param>
+        /// <returns>A YotiHttpResponse containing the SharedReceiptResponse and HTTP headers</returns>
+        public async Task<Web.YotiHttpResponse<SharedReceiptResponse>> GetShareReceiptAsync(string receiptId)
+        {
+            return await _yotiDigitalClientEngine.GetShareReceiptWithHeadersAsync(_sdkId, _keyPair, ApiUri, receiptId).ConfigureAwait(false);
         }
         
         

--- a/src/Yoti.Auth/DigitalIdentityClientEngine.cs
+++ b/src/Yoti.Auth/DigitalIdentityClientEngine.cs
@@ -66,5 +66,29 @@ namespace Yoti.Auth
 
             return result;
         }
+
+        /// <summary>
+        /// Creates a share session and returns the result with HTTP response headers
+        /// </summary>
+        public async Task<Web.YotiHttpResponse<ShareSessionResult>> CreateShareSessionWithHeadersAsync(string sdkId, AsymmetricCipherKeyPair keyPair, Uri apiUrl, ShareSessionRequest shareSessionRequest)
+        {
+            Web.YotiHttpResponse<ShareSessionResult> result = await Task.Run(async () => await DigitalIdentityService.CreateShareSessionWithHeaders(
+                _httpClient, apiUrl, sdkId, keyPair, shareSessionRequest).ConfigureAwait(false))
+                .ConfigureAwait(false);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Gets a share receipt and returns the result with HTTP response headers
+        /// </summary>
+        public async Task<Web.YotiHttpResponse<SharedReceiptResponse>> GetShareReceiptWithHeadersAsync(string sdkId, AsymmetricCipherKeyPair keyPair, Uri apiUrl, string receiptId)
+        {
+            Web.YotiHttpResponse<SharedReceiptResponse> result = await Task.Run(async () => await DigitalIdentityService.GetShareReceiptWithHeaders(
+                _httpClient, sdkId, apiUrl, keyPair, receiptId).ConfigureAwait(false))
+                .ConfigureAwait(false);
+
+            return result;
+        }
     }
 }

--- a/src/Yoti.Auth/DocScan/DocScanClient.cs
+++ b/src/Yoti.Auth/DocScan/DocScanClient.cs
@@ -46,8 +46,8 @@ namespace Yoti.Auth.DocScan
         /// Creates a Doc Scan session using the supplied session specification
         /// </summary>
         /// <param name="sessionSpec">the Doc Scan session specification</param>
-        /// <returns>the session creation result</returns>
-        public async Task<CreateSessionResult> CreateSessionAsync(SessionSpecification sessionSpec)
+        /// <returns>A YotiHttpResponse containing the session creation result and HTTP headers</returns>
+        public async Task<Web.YotiHttpResponse<CreateSessionResult>> CreateSessionAsync(SessionSpecification sessionSpec)
         {
             _logger.Debug("Creating a Yoti Doc Scan session...");
 
@@ -58,8 +58,8 @@ namespace Yoti.Auth.DocScan
         /// Creates a Doc Scan session using the supplied session specification
         /// </summary>
         /// <param name="sessionSpec">the Doc Scan session specification</param>
-        /// <returns>the session creation result</returns>
-        public CreateSessionResult CreateSession(SessionSpecification sessionSpec)
+        /// <returns>A YotiHttpResponse containing the session creation result and HTTP headers</returns>
+        public Web.YotiHttpResponse<CreateSessionResult> CreateSession(SessionSpecification sessionSpec)
         {
             return CreateSessionAsync(sessionSpec).Result;
         }
@@ -68,8 +68,8 @@ namespace Yoti.Auth.DocScan
         /// Retrieves the state of a previously created Yoti Doc Scan session
         /// </summary>
         /// <param name="sessionId">The ID of the session</param>
-        /// <returns>The session state</returns>
-        public async Task<GetSessionResult> GetSessionAsync(string sessionId)
+        /// <returns>A YotiHttpResponse containing the session state and HTTP headers</returns>
+        public async Task<Web.YotiHttpResponse<GetSessionResult>> GetSessionAsync(string sessionId)
         {
             _logger.Debug($"Retrieving session '{sessionId}'");
 
@@ -80,8 +80,8 @@ namespace Yoti.Auth.DocScan
         /// Retrieves the state of a previously created Yoti Doc Scan session
         /// </summary>
         /// <param name="sessionId">The ID of the session</param>
-        /// <returns>The session state</returns>
-        public GetSessionResult GetSession(string sessionId)
+        /// <returns>A YotiHttpResponse containing the session state and HTTP headers</returns>
+        public Web.YotiHttpResponse<GetSessionResult> GetSession(string sessionId)
         {
             return GetSessionAsync(sessionId).Result;
         }

--- a/src/Yoti.Auth/DocScan/DocScanService.cs
+++ b/src/Yoti.Auth/DocScan/DocScanService.cs
@@ -36,7 +36,7 @@ namespace Yoti.Auth.DocScan
             ApiUri = apiUri;
         }
 
-        public async Task<CreateSessionResult> CreateSession(string sdkId, AsymmetricCipherKeyPair keyPair, SessionSpecification sessionSpec)
+        public async Task<YotiHttpResponse<CreateSessionResult>> CreateSession(string sdkId, AsymmetricCipherKeyPair keyPair, SessionSpecification sessionSpec)
         {
             Validation.NotNullOrEmpty(sdkId, nameof(sdkId));
             Validation.NotNull(keyPair, nameof(keyPair));
@@ -49,13 +49,13 @@ namespace Yoti.Auth.DocScan
                 .WithKeyPair(keyPair)
                 .WithHttpMethod(HttpMethod.Post)
                 .WithBaseUri(ApiUri)
-                .WithEndpoint("/sessions")
+                .WithEndpoint("sessions")
                 .WithQueryParam("sdkId", sdkId)
                 .WithContent(body)
                 .WithContentHeader(Api.ContentTypeHeader, Api.ContentTypeJson)
                 .Build();
 
-            using (HttpResponseMessage response = await createSessionRequest.Execute(_httpClient).ConfigureAwait(false))
+            return await createSessionRequest.ExecuteWithHeaders(_httpClient, async response =>
             {
                 if (!response.IsSuccessStatusCode)
                 {
@@ -66,10 +66,8 @@ namespace Yoti.Auth.DocScan
                 var deserialized = await Task.Factory.StartNew(() => JsonConvert.DeserializeObject<CreateSessionResult>(responseObject));
 
                 return deserialized;
-            }
-        }
-
-        public async Task<GetSessionResult> GetSession(string sdkId, AsymmetricCipherKeyPair keyPair, string sessionId)
+            }).ConfigureAwait(false);
+        }        public async Task<YotiHttpResponse<GetSessionResult>> GetSession(string sdkId, AsymmetricCipherKeyPair keyPair, string sessionId)
         {
             Validation.NotNullOrEmpty(sdkId, nameof(sdkId));
             Validation.NotNull(keyPair, nameof(keyPair));
@@ -86,7 +84,7 @@ namespace Yoti.Auth.DocScan
                 .WithQueryParam("sdkId", sdkId)
                 .Build();
 
-            using (HttpResponseMessage response = await sessionRequest.Execute(_httpClient).ConfigureAwait(false))
+            return await sessionRequest.ExecuteWithHeaders(_httpClient, async response =>
             {
                 if (!response.IsSuccessStatusCode)
                 {
@@ -97,7 +95,7 @@ namespace Yoti.Auth.DocScan
                 var deserialized = await Task.Factory.StartNew(() => JsonConvert.DeserializeObject<GetSessionResult>(responseObject));
 
                 return deserialized;
-            }
+            }).ConfigureAwait(false);
         }
 
         public async Task DeleteSession(string sdkId, AsymmetricCipherKeyPair keyPair, string sessionId)

--- a/src/Yoti.Auth/Examples/RequestHeaderExample.cs
+++ b/src/Yoti.Auth/Examples/RequestHeaderExample.cs
@@ -1,0 +1,141 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Yoti.Auth;
+using Yoti.Auth.DigitalIdentity;
+using Yoti.Auth.DigitalIdentity.Policy;
+using Yoti.Auth.DocScan;
+using Yoti.Auth.DocScan.Session.Create;
+
+namespace Yoti.Auth.Examples
+{
+    /// <summary>
+    /// Example demonstrating how to access HTTP response headers from Yoti API calls
+    /// All existing methods now return headers - no need for separate WithHeaders methods!
+    /// </summary>
+    public class RequestHeaderExample
+    {
+        public async Task DemonstrateHeaderAccess()
+        {
+            // Initialize client (same as before)
+            string sdkId = "your-sdk-id";
+            var keyStream = new StreamReader(File.OpenRead("path-to-your-private-key.pem"));
+            var client = new DigitalIdentityClient(sdkId, keyStream);
+
+            // Create a share session request with correct method names
+            var shareSessionRequest = new ShareSessionRequestBuilder()
+                .WithPolicy(new PolicyBuilder()
+                    .WithDateOfBirth()
+                    .Build())
+                .WithRedirectUri("https://your-callback-endpoint.com")
+                .Build();
+
+            try
+            {
+                // Existing methods now return headers automatically!
+                var sessionResultWithHeaders = await client.CreateShareSessionAsync(shareSessionRequest);
+                
+                // Access the actual data (implicit conversion from YotiHttpResponse<T> to T)
+                ShareSessionResult sessionResult = sessionResultWithHeaders;
+                Console.WriteLine($"Session ID: {sessionResult.Id}");
+                Console.WriteLine($"Session Status: {sessionResult.Status}");
+                
+                // Access headers directly
+                string requestId = sessionResultWithHeaders.RequestId; // Shortcut for X-Request-ID
+                Console.WriteLine($"Request ID for troubleshooting: {requestId}");
+                
+                // Access other headers
+                string serverHeader = sessionResultWithHeaders.GetHeaderValue("Server");
+                Console.WriteLine($"Server: {serverHeader}");
+                
+                // Get a receipt - this method also returns headers now!
+                var receiptWithHeaders = await client.GetShareReceiptAsync("some-receipt-id");
+                
+                // Both the receipt data and headers are available
+                var receipt = receiptWithHeaders.Data; // or implicit: SharedReceiptResponse receipt = receiptWithHeaders;
+                var receiptHeaders = receiptWithHeaders.Headers;
+                
+                if (receiptWithHeaders.RequestId != null)
+                {
+                    Console.WriteLine($"Receipt Request ID: {receiptWithHeaders.RequestId}");
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error: {ex.Message}");
+            }
+        }
+
+        public async Task DemonstrateDocScanHeaderAccess()
+        {
+            // DocScan example - all methods now return headers too!
+            string sdkId = "your-sdk-id";
+            var keyStream = new StreamReader(File.OpenRead("path-to-your-private-key.pem"));
+            var docScanClient = new DocScanClient(sdkId, keyStream);
+            
+            try
+            {
+                // Create session specification
+                var sessionSpec = new SessionSpecificationBuilder()
+                    .WithClientSessionTokenTtl(600)
+                    .Build();
+
+                // Create session - method now returns headers automatically
+                var createSessionResultWithHeaders = await docScanClient.CreateSessionAsync(sessionSpec);
+                
+                // Access data and headers
+                var createResult = createSessionResultWithHeaders.Data;
+                string createRequestId = createSessionResultWithHeaders.RequestId;
+                
+                Console.WriteLine($"Created Session ID: {createResult.SessionId}");
+                Console.WriteLine($"Create Session Request ID: {createRequestId}");
+                
+                // Get session - this method also returns headers now
+                var getSessionResultWithHeaders = await docScanClient.GetSessionAsync(createResult.SessionId);
+                
+                var sessionData = getSessionResultWithHeaders.Data;
+                string getRequestId = getSessionResultWithHeaders.RequestId;
+                
+                Console.WriteLine($"Session State: {sessionData.State}");
+                Console.WriteLine($"Get Session Request ID: {getRequestId}");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"DocScan Error: {ex.Message}");
+            }
+        }
+
+        public void DemonstrateSyncHeaderAccess()
+        {
+            // Synchronous methods also return headers now!
+            string sdkId = "your-sdk-id";
+            var keyStream = new StreamReader(File.OpenRead("path-to-your-private-key.pem"));
+            var client = new DigitalIdentityClient(sdkId, keyStream);
+
+            var shareSessionRequest = new ShareSessionRequestBuilder()
+                .WithPolicy(new PolicyBuilder()
+                    .WithDateOfBirth()
+                    .Build())
+                .WithRedirectUri("https://your-callback-endpoint.com")
+                .Build();
+
+            try
+            {
+                // Sync method - returns headers too
+                var sessionResultWithHeaders = client.CreateShareSession(shareSessionRequest);
+                
+                Console.WriteLine($"Sync Session ID: {sessionResultWithHeaders.Data.Id}");
+                Console.WriteLine($"Sync Session Status: {sessionResultWithHeaders.Data.Status}");
+                
+                if (sessionResultWithHeaders.RequestId != null)
+                {
+                    Console.WriteLine($"Sync Request ID: {sessionResultWithHeaders.RequestId}");
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Sync Error: {ex.Message}");
+            }
+        }
+    }
+}

--- a/src/Yoti.Auth/Properties/AssemblyInfo.cs
+++ b/src/Yoti.Auth/Properties/AssemblyInfo.cs
@@ -5,9 +5,6 @@ using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following set of attributes.
 // Change these attribute values to modify the information associated with an assembly.
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Yoti")]
-[assembly: AssemblyProduct("Yoti.Auth")]
 [assembly: AssemblyTrademark("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible to COM components. If you

--- a/src/Yoti.Auth/Web/Request.cs
+++ b/src/Yoti.Auth/Web/Request.cs
@@ -1,4 +1,7 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace Yoti.Auth.Web
@@ -17,6 +20,28 @@ namespace Yoti.Auth.Web
             Validation.NotNull(httpClient, nameof(httpClient));
 
             return await httpClient.SendAsync(RequestMessage).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Executes the request and returns the response with headers
+        /// </summary>
+        /// <typeparam name="T">The type to deserialize the response to</typeparam>
+        /// <param name="httpClient">The HTTP client to use</param>
+        /// <param name="dataExtractor">Function to extract data from the HTTP response</param>
+        /// <returns>YotiHttpResponse containing both data and headers</returns>
+        public async Task<YotiHttpResponse<T>> ExecuteWithHeaders<T>(HttpClient httpClient, Func<HttpResponseMessage, Task<T>> dataExtractor)
+        {
+            Validation.NotNull(httpClient, nameof(httpClient));
+            Validation.NotNull(dataExtractor, nameof(dataExtractor));
+
+            using (HttpResponseMessage response = await Execute(httpClient).ConfigureAwait(false))
+            {
+                // Extract data using the provided function
+                T data = await dataExtractor(response).ConfigureAwait(false);
+
+                // Use the existing factory method that properly handles headers
+                return YotiHttpResponse<T>.FromHttpResponse(data, response);
+            }
         }
     }
 }

--- a/src/Yoti.Auth/Web/YotiHttpResponse.cs
+++ b/src/Yoti.Auth/Web/YotiHttpResponse.cs
@@ -1,0 +1,102 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+
+namespace Yoti.Auth.Web
+{
+    /// <summary>
+    /// Represents a response from the Yoti API containing both the response data and HTTP headers.
+    /// </summary>
+    /// <typeparam name="T">The type of the response data</typeparam>
+    public class YotiHttpResponse<T>
+    {
+        /// <summary>
+        /// The response data from the API
+        /// </summary>
+        public T Data { get; }
+
+        /// <summary>
+        /// The HTTP response headers from the API
+        /// </summary>
+        public IReadOnlyDictionary<string, IEnumerable<string>> Headers { get; }
+
+        /// <summary>
+        /// Gets the X-Request-ID header value if present
+        /// </summary>
+        public string RequestId => GetHeaderValue("X-Request-ID") ?? GetHeaderValue("X-Request-Id");
+
+        /// <summary>
+        /// Creates a new YotiHttpResponse
+        /// </summary>
+        /// <param name="data">The response data</param>
+        /// <param name="headers">The HTTP headers</param>
+        internal YotiHttpResponse(T data, IReadOnlyDictionary<string, IEnumerable<string>> headers)
+        {
+            Data = data;
+            Headers = headers;
+        }
+
+        /// <summary>
+        /// Creates a YotiHttpResponse from an HttpResponseMessage and response data
+        /// </summary>
+        /// <param name="data">The response data</param>
+        /// <param name="httpResponse">The HTTP response message</param>
+        /// <returns>A new YotiHttpResponse</returns>
+        internal static YotiHttpResponse<T> FromHttpResponse(T data, HttpResponseMessage httpResponse)
+        {
+            var headers = new Dictionary<string, IEnumerable<string>>();
+
+            // Add response headers
+            foreach (var header in httpResponse.Headers)
+            {
+                headers[header.Key] = header.Value;
+            }
+
+            // Add content headers if present
+            if (httpResponse.Content?.Headers != null)
+            {
+                foreach (var header in httpResponse.Content.Headers)
+                {
+                    headers[header.Key] = header.Value;
+                }
+            }
+
+            return new YotiHttpResponse<T>(data, headers);
+        }
+
+        /// <summary>
+        /// Gets the first value of a header with the specified name (case-insensitive)
+        /// </summary>
+        /// <param name="headerName">The name of the header</param>
+        /// <returns>The first header value, or null if not found</returns>
+        public string GetHeaderValue(string headerName)
+        {
+            var header = Headers.FirstOrDefault(h => 
+                string.Equals(h.Key, headerName, System.StringComparison.OrdinalIgnoreCase));
+            
+            return header.Value?.FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Gets all values of a header with the specified name (case-insensitive)
+        /// </summary>
+        /// <param name="headerName">The name of the header</param>
+        /// <returns>All header values, or an empty enumerable if not found</returns>
+        public IEnumerable<string> GetHeaderValues(string headerName)
+        {
+            var header = Headers.FirstOrDefault(h => 
+                string.Equals(h.Key, headerName, System.StringComparison.OrdinalIgnoreCase));
+            
+            return header.Value ?? Enumerable.Empty<string>();
+        }
+
+        /// <summary>
+        /// Implicitly converts to the underlying data type for backward compatibility
+        /// </summary>
+        /// <param name="response">The YotiHttpResponse to convert</param>
+        public static implicit operator T(YotiHttpResponse<T> response)
+        {
+            return response.Data;
+        }
+    }
+}

--- a/src/Yoti.Auth/Yoti.Auth.csproj
+++ b/src/Yoti.Auth/Yoti.Auth.csproj
@@ -9,6 +9,11 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <DebugType>Full</DebugType>
     <Authors>Yoti</Authors>
     <Description>Yoti .NET SDK, providing Yoti API support for Login, Verify (2FA) and Age Verification</Description>

--- a/test/Yoti.Auth.Tests/Properties/AssemblyInfo.cs
+++ b/test/Yoti.Auth.Tests/Properties/AssemblyInfo.cs
@@ -3,9 +3,6 @@ using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following set of attributes.
 // Change these attribute values to modify the information associated with an assembly.
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Yoti.Auth.Tests")]
 [assembly: AssemblyTrademark("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible to COM components. If you

--- a/test/Yoti.Auth.Tests/Web/YotiHttpResponseTests.cs
+++ b/test/Yoti.Auth.Tests/Web/YotiHttpResponseTests.cs
@@ -1,0 +1,273 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Yoti.Auth.Web;
+
+namespace Yoti.Auth.Tests.Web
+{
+    [TestClass]
+    public class YotiHttpResponseTests
+    {
+        [TestMethod]
+        public void ShouldCreateFromHttpResponseMessage()
+        {
+            // Arrange
+            var testData = "test data";
+            var httpResponse = new HttpResponseMessage();
+            httpResponse.Headers.Add("X-Request-ID", "test-request-id-123");
+            httpResponse.Headers.Add("Custom-Header", "custom-value");
+
+            // Act
+            var response = YotiHttpResponse<string>.FromHttpResponse(testData, httpResponse);
+
+            // Assert
+            Assert.AreEqual(testData, response.Data);
+            Assert.AreEqual("test-request-id-123", response.RequestId);
+            Assert.AreEqual("custom-value", response.GetHeaderValue("Custom-Header"));
+        }
+
+        [TestMethod]
+        public void ShouldHandleXRequestIdWithDifferentCasing()
+        {
+            // Arrange
+            var testData = "test data";
+            var httpResponse = new HttpResponseMessage();
+            httpResponse.Headers.Add("X-Request-Id", "test-request-id-456"); // Different casing
+
+            // Act
+            var response = YotiHttpResponse<string>.FromHttpResponse(testData, httpResponse);
+
+            // Assert
+            Assert.AreEqual("test-request-id-456", response.RequestId);
+        }
+
+        [TestMethod]
+        public void ShouldReturnNullWhenRequestIdNotPresent()
+        {
+            // Arrange
+            var testData = "test data";
+            var httpResponse = new HttpResponseMessage();
+            httpResponse.Headers.Add("Other-Header", "other-value");
+
+            // Act
+            var response = YotiHttpResponse<string>.FromHttpResponse(testData, httpResponse);
+
+            // Assert
+            Assert.IsNull(response.RequestId);
+        }
+
+        [TestMethod]
+        public void ShouldGetHeaderValueCaseInsensitive()
+        {
+            // Arrange
+            var testData = "test data";
+            var httpResponse = new HttpResponseMessage();
+            httpResponse.Content = new StringContent("test content");
+            httpResponse.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
+
+            // Act
+            var response = YotiHttpResponse<string>.FromHttpResponse(testData, httpResponse);
+
+            // Assert
+            Assert.AreEqual("application/json", response.GetHeaderValue("content-type"));
+            Assert.AreEqual("application/json", response.GetHeaderValue("Content-Type"));
+            Assert.AreEqual("application/json", response.GetHeaderValue("CONTENT-TYPE"));
+        }
+
+        [TestMethod]
+        public void ShouldGetMultipleHeaderValues()
+        {
+            // Arrange
+            var testData = "test data";
+            var httpResponse = new HttpResponseMessage();
+            httpResponse.Headers.Add("Accept", new[] { "application/json", "text/html" });
+
+            // Act
+            var response = YotiHttpResponse<string>.FromHttpResponse(testData, httpResponse);
+
+            // Assert
+            var acceptValues = response.GetHeaderValues("Accept").ToList();
+            Assert.AreEqual(2, acceptValues.Count);
+            Assert.IsTrue(acceptValues.Contains("application/json"));
+            Assert.IsTrue(acceptValues.Contains("text/html"));
+        }
+
+        [TestMethod]
+        public void ShouldReturnEmptyEnumerableForNonExistentHeader()
+        {
+            // Arrange
+            var testData = "test data";
+            var httpResponse = new HttpResponseMessage();
+
+            // Act
+            var response = YotiHttpResponse<string>.FromHttpResponse(testData, httpResponse);
+
+            // Assert
+            var values = response.GetHeaderValues("Non-Existent-Header");
+            Assert.IsNotNull(values);
+            Assert.AreEqual(0, values.Count());
+        }
+
+        [TestMethod]
+        public void ShouldImplicitlyConvertToDataType()
+        {
+            // Arrange
+            var testData = "test data";
+            var httpResponse = new HttpResponseMessage();
+            var response = YotiHttpResponse<string>.FromHttpResponse(testData, httpResponse);
+
+            // Act
+            string implicitData = response; // Implicit conversion
+
+            // Assert
+            Assert.AreEqual(testData, implicitData);
+        }
+
+        [TestMethod]
+        public void ShouldIncludeBothResponseAndContentHeaders()
+        {
+            // Arrange
+            var testData = "test data";
+            var httpResponse = new HttpResponseMessage();
+            httpResponse.Headers.Add("Response-Header", "response-value");
+            httpResponse.Content = new StringContent("content");
+            httpResponse.Content.Headers.Add("Content-Header", "content-value");
+
+            // Act
+            var response = YotiHttpResponse<string>.FromHttpResponse(testData, httpResponse);
+
+            // Assert
+            Assert.AreEqual("response-value", response.GetHeaderValue("Response-Header"));
+            Assert.AreEqual("content-value", response.GetHeaderValue("Content-Header"));
+        }
+
+        [TestMethod]
+        public void ShouldHandleRequestIdWithVariousCasings()
+        {
+            // Arrange
+            var testData = "test data";
+            const string expectedRequestId = "req-ABC123-def456";
+
+            // Test different casing variations of X-Request-ID
+            var testCases = new[]
+            {
+                "X-Request-ID",
+                "X-Request-Id", 
+                "x-request-id",
+                "X-REQUEST-ID",
+                "x-Request-Id"
+            };
+
+            foreach (var headerName in testCases)
+            {
+                var httpResponse = new HttpResponseMessage();
+                httpResponse.Headers.Add(headerName, expectedRequestId);
+
+                // Act
+                var response = YotiHttpResponse<string>.FromHttpResponse(testData, httpResponse);
+
+                // Assert
+                Assert.AreEqual(expectedRequestId, response.RequestId, 
+                    $"Failed for header name: {headerName}");
+            }
+        }
+
+        [TestMethod]
+        public void ShouldHandleCommonYotiHeaders()
+        {
+            // Arrange
+            var testData = "test data";
+            var httpResponse = new HttpResponseMessage();
+            httpResponse.Headers.Add("X-Request-ID", "req-12345");
+            httpResponse.Headers.Add("X-Yoti-Session-ID", "session-abc123");
+            httpResponse.Headers.Add("X-RateLimit-Limit", "1000");
+            httpResponse.Headers.Add("X-RateLimit-Remaining", "999");
+            httpResponse.Headers.Add("X-RateLimit-Reset", "1640995200");
+            httpResponse.Headers.Add("Server", "Yoti-API-Gateway/2.1");
+
+            // Act
+            var response = YotiHttpResponse<string>.FromHttpResponse(testData, httpResponse);
+
+            // Assert
+            Assert.AreEqual("req-12345", response.RequestId);
+            Assert.AreEqual("session-abc123", response.GetHeaderValue("X-Yoti-Session-ID"));
+            Assert.AreEqual("1000", response.GetHeaderValue("X-RateLimit-Limit"));
+            Assert.AreEqual("999", response.GetHeaderValue("X-RateLimit-Remaining"));
+            Assert.AreEqual("1640995200", response.GetHeaderValue("X-RateLimit-Reset"));
+            Assert.AreEqual("Yoti-API-Gateway/2.1", response.GetHeaderValue("Server"));
+        }
+
+        [TestMethod]
+        public void ShouldHandleSecurityHeaders()
+        {
+            // Arrange
+            var testData = "test data";
+            var httpResponse = new HttpResponseMessage();
+            httpResponse.Headers.Add("X-Request-ID", "req-security-test");
+            httpResponse.Headers.Add("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+            httpResponse.Headers.Add("X-Content-Type-Options", "nosniff");
+            httpResponse.Headers.Add("X-Frame-Options", "DENY");
+            httpResponse.Headers.Add("X-XSS-Protection", "1; mode=block");
+
+            // Act
+            var response = YotiHttpResponse<string>.FromHttpResponse(testData, httpResponse);
+
+            // Assert
+            Assert.AreEqual("req-security-test", response.RequestId);
+            Assert.AreEqual("max-age=31536000; includeSubDomains", response.GetHeaderValue("Strict-Transport-Security"));
+            Assert.AreEqual("nosniff", response.GetHeaderValue("X-Content-Type-Options"));
+            Assert.AreEqual("DENY", response.GetHeaderValue("X-Frame-Options"));
+            Assert.AreEqual("1; mode=block", response.GetHeaderValue("X-XSS-Protection"));
+        }
+
+        [TestMethod]
+        public void ShouldHandleCacheHeaders()
+        {
+            // Arrange
+            var testData = "test data";
+            var httpResponse = new HttpResponseMessage();
+            httpResponse.Headers.Add("X-Request-ID", "req-cache-test");
+            httpResponse.Headers.Add("Cache-Control", "no-cache, no-store, must-revalidate");
+            httpResponse.Headers.Add("Pragma", "no-cache");
+            httpResponse.Headers.Add("ETag", @"""session-abc123-v1""");
+            // Set Expires header properly
+            httpResponse.Content = new StringContent("test");
+            httpResponse.Content.Headers.Expires = DateTimeOffset.MinValue;
+
+            // Act
+            var response = YotiHttpResponse<string>.FromHttpResponse(testData, httpResponse);
+
+            // Assert
+            Assert.AreEqual("req-cache-test", response.RequestId);
+            Assert.IsTrue(response.GetHeaderValue("Cache-Control").Contains("no-cache"));
+            Assert.IsTrue(response.GetHeaderValue("Cache-Control").Contains("no-store"));
+            Assert.IsTrue(response.GetHeaderValue("Cache-Control").Contains("must-revalidate"));
+            Assert.AreEqual("no-cache", response.GetHeaderValue("Pragma"));
+            Assert.AreEqual(@"""session-abc123-v1""", response.GetHeaderValue("ETag"));
+            Assert.IsNotNull(response.GetHeaderValue("Expires")); // Just check it exists
+        }
+
+        [TestMethod]
+        public void ShouldHandleErrorResponseHeaders()
+        {
+            // Arrange
+            var testData = "error data";
+            var httpResponse = new HttpResponseMessage(System.Net.HttpStatusCode.BadRequest);
+            httpResponse.Headers.Add("X-Request-ID", "req-error-400");
+            httpResponse.Headers.Add("X-Error-Code", "INVALID_REQUEST");
+            httpResponse.Headers.Add("X-Error-Message", "Missing required parameter");
+            httpResponse.Headers.Add("Retry-After", "30");
+
+            // Act
+            var response = YotiHttpResponse<string>.FromHttpResponse(testData, httpResponse);
+
+            // Assert
+            Assert.AreEqual("req-error-400", response.RequestId);
+            Assert.AreEqual("INVALID_REQUEST", response.GetHeaderValue("X-Error-Code"));
+            Assert.AreEqual("Missing required parameter", response.GetHeaderValue("X-Error-Message"));
+            Assert.AreEqual("30", response.GetHeaderValue("Retry-After"));
+        }
+    }
+}

--- a/test/Yoti.Auth.Tests/Yoti.Auth.Tests.csproj
+++ b/test/Yoti.Auth.Tests/Yoti.Auth.Tests.csproj
@@ -9,6 +9,11 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <DebugType>Full</DebugType>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>


### PR DESCRIPTION
This PR adds the ability to access HTTP response headers (including X-Request-ID) from API calls in the Yoti .NET SDK, addressing client troubleshooting needs for connection timeout issues while maintaining full backward compatibility.

