### PR TITLE
Sdk 2221 net allow rb to supply an applicant profile for identity profile sessions

### DIFF
--- a/src/Examples/DocScan/DocScanExample/Controllers/HomeController.cs
+++ b/src/Examples/DocScan/DocScanExample/Controllers/HomeController.cs
@@ -43,7 +43,7 @@ namespace DocScanExample.Controllers
             //Build Session Spec
             var sessionSpec = new SessionSpecificationBuilder()
                 .WithClientSessionTokenTtl(600)
-                .WithResourcesTtl(86400)
+                .WithResourcesTtl(90400)
                 .WithUserTrackingId("some-user-tracking-id")
                 //Add Checks (using builders)
                 .WithRequestedCheck(

--- a/src/Examples/DocScan/DocScanExample/Controllers/IdentityProfileController.cs
+++ b/src/Examples/DocScan/DocScanExample/Controllers/IdentityProfileController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -16,14 +16,14 @@ using Yoti.Auth.DocScan.Session.Create.Task;
  
 namespace DocScanExample.Controllers
 {
-    public class DbsController : Controller
+    public class IdentityProfileController : Controller
     {
         private readonly DocScanClient _client;
 
         private readonly string _baseUrl;
         private readonly Uri _apiUrl;
 
-        public DbsController(IHttpContextAccessor httpContextAccessor)
+        public IdentityProfileController(IHttpContextAccessor httpContextAccessor)
         {
             var request = httpContextAccessor.HttpContext.Request;
             
@@ -34,16 +34,40 @@ namespace DocScanExample.Controllers
 
         public IActionResult Index()
         {
+            // Build Structured Postal Address
+            var structuredPostalAddress = new StructuredPostalAddressBuilder()
+                .WithAddressFormat(1)
+                .WithBuildingNumber("74")
+                .WithAddressLine1("AddressLine1")
+                .WithTownCity("CityName")
+                .WithPostalCode("E143RN")
+                .WithCountryIso("GBR")
+                .WithCountry("United Kingdom")
+                .WithFormattedAddress("74\nAddressLine1\nCityName\nE143RN\nGBR")
+                .Build();
+
+            // Build Applicant Profile
+            var applicantProfile = new ApplicantProfileBuilder()
+                .WithFullName("John Doe")
+                .WithDateOfBirth("1988-11-02")
+                .WithNamePrefix("Mr")
+                .WithStructuredPostalAddress(structuredPostalAddress)
+                .Build();
+
+            // Build Resource Creation Container
+            var resources = new ResourceCreationContainerBuilder()
+                .WithApplicantProfile(applicantProfile)
+                .Build();
 
             //Build Session Spec
             var sessionSpec = new SessionSpecificationBuilder()
                 .WithClientSessionTokenTtl(600)
-                .WithResourcesTtl(90000)
+                .WithResourcesTtl(96400)
                 .WithUserTrackingId("some-user-tracking-id")
                 //Add Sdk Config (with builder)
                 .WithSdkConfig(
                     new SdkConfigBuilder()
-                    .WithAllowsCameraAndUpload()
+                    //.WithAllowsCameraAndUpload()
                     .WithPrimaryColour("#2d9fff")
                     .WithSecondaryColour("#FFFFFF")
                     .WithFontColour("#FFFFFF")
@@ -67,7 +91,9 @@ namespace DocScanExample.Controllers
                 .WithSubject(new
                 {
                     subject_id = "some_subject_id_string"
-                })    
+                })
+                // Add Resources with Applicant Profile
+                .WithResources(resources)
             .Build();
 
             CreateSessionResult createSessionResult = _client.CreateSession(sessionSpec);

--- a/src/Examples/DocScan/DocScanExample/Controllers/IdentityProfileController.cs
+++ b/src/Examples/DocScan/DocScanExample/Controllers/IdentityProfileController.cs
@@ -26,8 +26,8 @@ namespace DocScanExample.Controllers
         public IdentityProfileController(IHttpContextAccessor httpContextAccessor)
         {
             var request = httpContextAccessor.HttpContext.Request;
-            
-            _baseUrl = $"{request.Scheme}://{request.Host}"; ;
+
+            _baseUrl = $"{request.Scheme}://{request.Host}";
             _apiUrl = GetApiUrl();
             _client = GetDocScanClient(_apiUrl);
         }
@@ -126,12 +126,13 @@ namespace DocScanExample.Controllers
             if (apiUrl == null)
                 apiUrl = GetApiUrl();
 
-            StreamReader privateKeyStream = System.IO.File.OpenText(Environment.GetEnvironmentVariable("YOTI_KEY_FILE_PATH"));
-            var key = CryptoEngine.LoadRsaKey(privateKeyStream);
-
-            string clientSdkId = Environment.GetEnvironmentVariable("YOTI_CLIENT_SDK_ID");
-
-            return new DocScanClient(clientSdkId, key, new HttpClient(), apiUrl);
+            string keyFilePath = Environment.GetEnvironmentVariable("YOTI_KEY_FILE_PATH");
+            using (StreamReader privateKeyStream = System.IO.File.OpenText(keyFilePath))
+            {
+                var key = CryptoEngine.LoadRsaKey(privateKeyStream);
+                string clientSdkId = Environment.GetEnvironmentVariable("YOTI_CLIENT_SDK_ID");
+                return new DocScanClient(clientSdkId, key, new HttpClient(), apiUrl);
+            }
         }
 
         internal static Uri GetApiUrl()

--- a/src/Examples/DocScan/DocScanExample/Views/IdentityProfile/Index.cshtml
+++ b/src/Examples/DocScan/DocScanExample/Views/IdentityProfile/Index.cshtml
@@ -1,4 +1,4 @@
 @{
     ViewData["Title"] = "Identity Profile Page";
 }
-<iframe style="border:none;" width="100%" height="750" allow="camera" src="@ViewBag.iframeUrl" allowfullscreen></iframe>
+<iframe style="border:none;" width="100%" height="750" allow="camera" src="@ViewBag.iframeUrl" allowfullscreen title="Identity profile verification content"></iframe>

--- a/src/Examples/DocScan/DocScanExample/Views/IdentityProfile/Index.cshtml
+++ b/src/Examples/DocScan/DocScanExample/Views/IdentityProfile/Index.cshtml
@@ -1,0 +1,4 @@
+@{
+    ViewData["Title"] = "Identity Profile Page";
+}
+<iframe style="border:none;" width="100%" height="750" allow="camera" src="@ViewBag.iframeUrl" allowfullscreen></iframe>

--- a/src/Yoti.Auth/DocScan/Session/Create/ApplicantProfile.cs
+++ b/src/Yoti.Auth/DocScan/Session/Create/ApplicantProfile.cs
@@ -1,0 +1,34 @@
+using Newtonsoft.Json;
+
+namespace Yoti.Auth.DocScan.Session.Create
+{
+    /// <summary>
+    /// Represents an applicant profile to be used for verification against identity documents.
+    /// </summary>
+    public class ApplicantProfile
+    {
+        internal ApplicantProfile(
+            string fullName,
+            string dateOfBirth,
+            string namePrefix,
+            StructuredPostalAddress structuredPostalAddress)
+        {
+            FullName = fullName;
+            DateOfBirth = dateOfBirth;
+            NamePrefix = namePrefix;
+            StructuredPostalAddress = structuredPostalAddress;
+        }
+
+        [JsonProperty(PropertyName = "full_name")]
+        public string FullName { get; }
+
+        [JsonProperty(PropertyName = "date_of_birth")]
+        public string DateOfBirth { get; }
+
+        [JsonProperty(PropertyName = "name_prefix")]
+        public string NamePrefix { get; }
+
+        [JsonProperty(PropertyName = "structured_postal_address")]
+        public StructuredPostalAddress StructuredPostalAddress { get; }
+    }
+}

--- a/src/Yoti.Auth/DocScan/Session/Create/ApplicantProfileBuilder.cs
+++ b/src/Yoti.Auth/DocScan/Session/Create/ApplicantProfileBuilder.cs
@@ -1,0 +1,70 @@
+namespace Yoti.Auth.DocScan.Session.Create
+{
+    /// <summary>
+    /// Builder for <see cref="ApplicantProfile"/>.
+    /// </summary>
+    public class ApplicantProfileBuilder
+    {
+        private string _fullName;
+        private string _dateOfBirth;
+        private string _namePrefix;
+        private StructuredPostalAddress _structuredPostalAddress;
+
+        /// <summary>
+        /// Sets the full name of the applicant
+        /// </summary>
+        /// <param name="fullName">The full name</param>
+        /// <returns>the builder</returns>
+        public ApplicantProfileBuilder WithFullName(string fullName)
+        {
+            _fullName = fullName;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the date of birth of the applicant
+        /// </summary>
+        /// <param name="dateOfBirth">The date of birth (e.g. "1988-11-02")</param>
+        /// <returns>the builder</returns>
+        public ApplicantProfileBuilder WithDateOfBirth(string dateOfBirth)
+        {
+            _dateOfBirth = dateOfBirth;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the name prefix of the applicant
+        /// </summary>
+        /// <param name="namePrefix">The name prefix (e.g. "Mr")</param>
+        /// <returns>the builder</returns>
+        public ApplicantProfileBuilder WithNamePrefix(string namePrefix)
+        {
+            _namePrefix = namePrefix;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the structured postal address of the applicant
+        /// </summary>
+        /// <param name="structuredPostalAddress">The <see cref="StructuredPostalAddress"/></param>
+        /// <returns>the builder</returns>
+        public ApplicantProfileBuilder WithStructuredPostalAddress(StructuredPostalAddress structuredPostalAddress)
+        {
+            _structuredPostalAddress = structuredPostalAddress;
+            return this;
+        }
+
+        /// <summary>
+        /// Builds the <see cref="ApplicantProfile"/> based on the values supplied to the builder.
+        /// </summary>
+        /// <returns>The built <see cref="ApplicantProfile"/></returns>
+        public ApplicantProfile Build()
+        {
+            return new ApplicantProfile(
+                _fullName,
+                _dateOfBirth,
+                _namePrefix,
+                _structuredPostalAddress);
+        }
+    }
+}

--- a/src/Yoti.Auth/DocScan/Session/Create/ResourceCreationContainer.cs
+++ b/src/Yoti.Auth/DocScan/Session/Create/ResourceCreationContainer.cs
@@ -1,0 +1,21 @@
+using Newtonsoft.Json;
+
+namespace Yoti.Auth.DocScan.Session.Create
+{
+    /// <summary>
+    /// Container for resources to be created as part of a session.
+    /// </summary>
+    public class ResourceCreationContainer
+    {
+        internal ResourceCreationContainer(ApplicantProfile applicantProfile)
+        {
+            ApplicantProfile = applicantProfile;
+        }
+
+        /// <summary>
+        /// The applicant profile to be used for verification against identity documents.
+        /// </summary>
+        [JsonProperty(PropertyName = "applicant_profile")]
+        public ApplicantProfile ApplicantProfile { get; }
+    }
+}

--- a/src/Yoti.Auth/DocScan/Session/Create/ResourceCreationContainerBuilder.cs
+++ b/src/Yoti.Auth/DocScan/Session/Create/ResourceCreationContainerBuilder.cs
@@ -1,0 +1,30 @@
+namespace Yoti.Auth.DocScan.Session.Create
+{
+    /// <summary>
+    /// Builder for <see cref="ResourceCreationContainer"/>.
+    /// </summary>
+    public class ResourceCreationContainerBuilder
+    {
+        private ApplicantProfile _applicantProfile;
+
+        /// <summary>
+        /// Sets the applicant profile to be used for verification against identity documents.
+        /// </summary>
+        /// <param name="applicantProfile">The <see cref="ApplicantProfile"/> for the session</param>
+        /// <returns>the builder</returns>
+        public ResourceCreationContainerBuilder WithApplicantProfile(ApplicantProfile applicantProfile)
+        {
+            _applicantProfile = applicantProfile;
+            return this;
+        }
+
+        /// <summary>
+        /// Builds the <see cref="ResourceCreationContainer"/> based on the values supplied to the builder.
+        /// </summary>
+        /// <returns>The built <see cref="ResourceCreationContainer"/></returns>
+        public ResourceCreationContainer Build()
+        {
+            return new ResourceCreationContainer(_applicantProfile);
+        }
+    }
+}

--- a/src/Yoti.Auth/DocScan/Session/Create/SessionSpecification.cs
+++ b/src/Yoti.Auth/DocScan/Session/Create/SessionSpecification.cs
@@ -9,7 +9,7 @@ namespace Yoti.Auth.DocScan.Session.Create
 {
     public class SessionSpecification
     {
-        internal SessionSpecification(int? clientSessionTokenTtl, int? resourcesTtl, string userTrackingId, NotificationConfig notifications, List<BaseRequestedCheck> requestedChecks, List<BaseRequestedTask> requestedTasks, SdkConfig sdkConfig, List<RequiredDocument> requiredDocuments, bool? blockBiometricConsent, DateTimeOffset? sessionDeadline, object identityProfileRequirements, object subject, bool createIdentityProfilePreview)
+        internal SessionSpecification(int? clientSessionTokenTtl, int? resourcesTtl, string userTrackingId, NotificationConfig notifications, List<BaseRequestedCheck> requestedChecks, List<BaseRequestedTask> requestedTasks, SdkConfig sdkConfig, List<RequiredDocument> requiredDocuments, bool? blockBiometricConsent, DateTimeOffset? sessionDeadline, object identityProfileRequirements, object subject, bool createIdentityProfilePreview, ResourceCreationContainer resources)
         {
             ClientSessionTokenTtl = clientSessionTokenTtl;
             ResourcesTtl = resourcesTtl;
@@ -24,6 +24,7 @@ namespace Yoti.Auth.DocScan.Session.Create
             IdentityProfileRequirements = identityProfileRequirements;
             Subject = subject;
             CreateIdentityProfilePreview = createIdentityProfilePreview;
+            Resources = resources;
         }
 
         [JsonProperty(PropertyName = "client_session_token_ttl")]
@@ -64,5 +65,8 @@ namespace Yoti.Auth.DocScan.Session.Create
 
         [JsonProperty(PropertyName = "subject")]
         public object Subject { get; }
+
+        [JsonProperty(PropertyName = "resources")]
+        public ResourceCreationContainer Resources { get; }
     }
 }

--- a/src/Yoti.Auth/DocScan/Session/Create/SessionSpecificationBuilder.cs
+++ b/src/Yoti.Auth/DocScan/Session/Create/SessionSpecificationBuilder.cs
@@ -21,6 +21,7 @@ namespace Yoti.Auth.DocScan.Session.Create
         private object _identityProfileRequirements;
         private object _subject;
         private bool _createIdentityProfilePreview;
+        private ResourceCreationContainer _resources;
 
         /// <summary>
         /// Sets the client session token TTL (time-to-live)
@@ -175,6 +176,17 @@ namespace Yoti.Auth.DocScan.Session.Create
         }
 
         /// <summary>
+        /// Sets the <see cref="ResourceCreationContainer"/> for the session
+        /// </summary>
+        /// <param name="resources">The <see cref="ResourceCreationContainer"/> for the session</param>
+        /// <returns>the builder</returns>
+        public SessionSpecificationBuilder WithResources(ResourceCreationContainer resources)
+        {
+            _resources = resources;
+            return this;
+        }
+
+        /// <summary>
         /// Builds the <see cref="SessionSpecification"/> based on the values supplied to the builder
         /// </summary>
         /// <returns>The built <see cref="SessionSpecification"/></returns>
@@ -193,7 +205,8 @@ namespace Yoti.Auth.DocScan.Session.Create
                 _sessionDeadline,
                 _identityProfileRequirements,
                 _subject,
-                _createIdentityProfilePreview
+                _createIdentityProfilePreview,
+                _resources
                 );
         }
     }

--- a/src/Yoti.Auth/DocScan/Session/Create/StructuredPostalAddress.cs
+++ b/src/Yoti.Auth/DocScan/Session/Create/StructuredPostalAddress.cs
@@ -1,0 +1,54 @@
+using Newtonsoft.Json;
+
+namespace Yoti.Auth.DocScan.Session.Create
+{
+    /// <summary>
+    /// Represents a structured postal address for an applicant profile.
+    /// </summary>
+    public class StructuredPostalAddress
+    {
+        internal StructuredPostalAddress(
+            int? addressFormat,
+            string buildingNumber,
+            string addressLine1,
+            string townCity,
+            string postalCode,
+            string countryIso,
+            string country,
+            string formattedAddress)
+        {
+            AddressFormat = addressFormat;
+            BuildingNumber = buildingNumber;
+            AddressLine1 = addressLine1;
+            TownCity = townCity;
+            PostalCode = postalCode;
+            CountryIso = countryIso;
+            Country = country;
+            FormattedAddress = formattedAddress;
+        }
+
+        [JsonProperty(PropertyName = "address_format")]
+        public int? AddressFormat { get; }
+
+        [JsonProperty(PropertyName = "building_number")]
+        public string BuildingNumber { get; }
+
+        [JsonProperty(PropertyName = "address_line1")]
+        public string AddressLine1 { get; }
+
+        [JsonProperty(PropertyName = "town_city")]
+        public string TownCity { get; }
+
+        [JsonProperty(PropertyName = "postal_code")]
+        public string PostalCode { get; }
+
+        [JsonProperty(PropertyName = "country_iso")]
+        public string CountryIso { get; }
+
+        [JsonProperty(PropertyName = "country")]
+        public string Country { get; }
+
+        [JsonProperty(PropertyName = "formatted_address")]
+        public string FormattedAddress { get; }
+    }
+}

--- a/src/Yoti.Auth/DocScan/Session/Create/StructuredPostalAddressBuilder.cs
+++ b/src/Yoti.Auth/DocScan/Session/Create/StructuredPostalAddressBuilder.cs
@@ -1,0 +1,122 @@
+namespace Yoti.Auth.DocScan.Session.Create
+{
+    /// <summary>
+    /// Builder for <see cref="StructuredPostalAddress"/>.
+    /// </summary>
+    public class StructuredPostalAddressBuilder
+    {
+        private int? _addressFormat;
+        private string _buildingNumber;
+        private string _addressLine1;
+        private string _townCity;
+        private string _postalCode;
+        private string _countryIso;
+        private string _country;
+        private string _formattedAddress;
+
+        /// <summary>
+        /// Sets the address format
+        /// </summary>
+        /// <param name="addressFormat">The address format</param>
+        /// <returns>the builder</returns>
+        public StructuredPostalAddressBuilder WithAddressFormat(int addressFormat)
+        {
+            _addressFormat = addressFormat;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the building number
+        /// </summary>
+        /// <param name="buildingNumber">The building number</param>
+        /// <returns>the builder</returns>
+        public StructuredPostalAddressBuilder WithBuildingNumber(string buildingNumber)
+        {
+            _buildingNumber = buildingNumber;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the address line 1
+        /// </summary>
+        /// <param name="addressLine1">The first address line</param>
+        /// <returns>the builder</returns>
+        public StructuredPostalAddressBuilder WithAddressLine1(string addressLine1)
+        {
+            _addressLine1 = addressLine1;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the town or city
+        /// </summary>
+        /// <param name="townCity">The town or city</param>
+        /// <returns>the builder</returns>
+        public StructuredPostalAddressBuilder WithTownCity(string townCity)
+        {
+            _townCity = townCity;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the postal code
+        /// </summary>
+        /// <param name="postalCode">The postal code</param>
+        /// <returns>the builder</returns>
+        public StructuredPostalAddressBuilder WithPostalCode(string postalCode)
+        {
+            _postalCode = postalCode;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the country ISO code
+        /// </summary>
+        /// <param name="countryIso">The country ISO code (e.g. "GBR")</param>
+        /// <returns>the builder</returns>
+        public StructuredPostalAddressBuilder WithCountryIso(string countryIso)
+        {
+            _countryIso = countryIso;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the country name
+        /// </summary>
+        /// <param name="country">The country name</param>
+        /// <returns>the builder</returns>
+        public StructuredPostalAddressBuilder WithCountry(string country)
+        {
+            _country = country;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the formatted address
+        /// </summary>
+        /// <param name="formattedAddress">The formatted address</param>
+        /// <returns>the builder</returns>
+        public StructuredPostalAddressBuilder WithFormattedAddress(string formattedAddress)
+        {
+            _formattedAddress = formattedAddress;
+            return this;
+        }
+
+        /// <summary>
+        /// Builds the <see cref="StructuredPostalAddress"/> based on the values supplied to the builder.
+        /// </summary>
+        /// <returns>The built <see cref="StructuredPostalAddress"/></returns>
+        public StructuredPostalAddress Build()
+        {
+            return new StructuredPostalAddress(
+                _addressFormat,
+                _buildingNumber,
+                _addressLine1,
+                _townCity,
+                _postalCode,
+                _countryIso,
+                _country,
+                _formattedAddress);
+        }
+    }
+}

--- a/src/Yoti.Auth/DocScan/Session/Retrieve/Resource/ApplicantProfileResourceResponse.cs
+++ b/src/Yoti.Auth/DocScan/Session/Retrieve/Resource/ApplicantProfileResourceResponse.cs
@@ -1,0 +1,13 @@
+using Newtonsoft.Json;
+
+namespace Yoti.Auth.DocScan.Session.Retrieve.Resource
+{
+    /// <summary>
+    /// Applicant Profile Resource Response wrapping a <see cref="MediaResponse"/>
+    /// </summary>
+    public class ApplicantProfileResourceResponse : ResourceResponse
+    {
+        [JsonProperty(PropertyName = "media")]
+        public MediaResponse Media { get; private set; }
+    }
+}

--- a/src/Yoti.Auth/DocScan/Session/Retrieve/Resource/ResourceContainer.cs
+++ b/src/Yoti.Auth/DocScan/Session/Retrieve/Resource/ResourceContainer.cs
@@ -17,6 +17,9 @@ namespace Yoti.Auth.DocScan.Session.Retrieve.Resource
         [JsonProperty(PropertyName = "face_capture")]
         public List<FaceCaptureResourceResponse> FaceCapture { get; internal set; }
 
+        [JsonProperty(PropertyName = "applicant_profiles")]
+        public List<ApplicantProfileResourceResponse> ApplicantProfiles { get; internal set; }
+
         public List<ZoomLivenessResourceResponse> ZoomLivenessResources
         {
             get

--- a/test/Yoti.Auth.Tests.Common/Yoti.Auth.Tests.Common.csproj
+++ b/test/Yoti.Auth.Tests.Common/Yoti.Auth.Tests.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/test/Yoti.Auth.Tests/DocScan/Session/Create/ApplicantProfileBuilderTests.cs
+++ b/test/Yoti.Auth.Tests/DocScan/Session/Create/ApplicantProfileBuilderTests.cs
@@ -1,0 +1,86 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using Yoti.Auth.DocScan.Session.Create;
+
+namespace Yoti.Auth.Tests.DocScan.Session.Create
+{
+    [TestClass]
+    public class ApplicantProfileBuilderTests
+    {
+        [TestMethod]
+        public void ShouldBuildWithFullName()
+        {
+            var profile = new ApplicantProfileBuilder()
+                .WithFullName("John Doe")
+                .Build();
+
+            Assert.AreEqual("John Doe", profile.FullName);
+        }
+
+        [TestMethod]
+        public void ShouldBuildWithDateOfBirth()
+        {
+            var profile = new ApplicantProfileBuilder()
+                .WithDateOfBirth("1988-11-02")
+                .Build();
+
+            Assert.AreEqual("1988-11-02", profile.DateOfBirth);
+        }
+
+        [TestMethod]
+        public void ShouldBuildWithNamePrefix()
+        {
+            var profile = new ApplicantProfileBuilder()
+                .WithNamePrefix("Mr")
+                .Build();
+
+            Assert.AreEqual("Mr", profile.NamePrefix);
+        }
+
+        [TestMethod]
+        public void ShouldBuildWithStructuredPostalAddress()
+        {
+            var address = new StructuredPostalAddressBuilder()
+                .WithBuildingNumber("74")
+                .WithPostalCode("E143RN")
+                .Build();
+
+            var profile = new ApplicantProfileBuilder()
+                .WithStructuredPostalAddress(address)
+                .Build();
+
+            Assert.AreEqual("74", profile.StructuredPostalAddress.BuildingNumber);
+            Assert.AreEqual("E143RN", profile.StructuredPostalAddress.PostalCode);
+        }
+
+        [TestMethod]
+        public void ShouldCorrectlySerializeWithAllProperties()
+        {
+            var address = new StructuredPostalAddressBuilder()
+                .WithAddressFormat(1)
+                .WithBuildingNumber("74")
+                .WithAddressLine1("AddressLine1")
+                .WithTownCity("CityName")
+                .WithPostalCode("E143RN")
+                .WithCountryIso("GBR")
+                .WithCountry("United Kingdom")
+                .Build();
+
+            var profile = new ApplicantProfileBuilder()
+                .WithFullName("John Doe")
+                .WithDateOfBirth("1988-11-02")
+                .WithNamePrefix("Mr")
+                .WithStructuredPostalAddress(address)
+                .Build();
+
+            string json = JsonConvert.SerializeObject(profile);
+
+            Assert.IsTrue(json.Contains("\"full_name\":\"John Doe\""));
+            Assert.IsTrue(json.Contains("\"date_of_birth\":\"1988-11-02\""));
+            Assert.IsTrue(json.Contains("\"name_prefix\":\"Mr\""));
+            Assert.IsTrue(json.Contains("\"structured_postal_address\""));
+            Assert.IsTrue(json.Contains("\"building_number\":\"74\""));
+            Assert.IsTrue(json.Contains("\"country_iso\":\"GBR\""));
+        }
+    }
+}

--- a/test/Yoti.Auth.Tests/DocScan/Session/Create/ResourceCreationContainerBuilderTests.cs
+++ b/test/Yoti.Auth.Tests/DocScan/Session/Create/ResourceCreationContainerBuilderTests.cs
@@ -1,0 +1,74 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using Yoti.Auth.DocScan.Session.Create;
+
+namespace Yoti.Auth.Tests.DocScan.Session.Create
+{
+    [TestClass]
+    public class ResourceCreationContainerBuilderTests
+    {
+        [TestMethod]
+        public void ShouldBuildWithApplicantProfile()
+        {
+            var applicantProfile = new ApplicantProfileBuilder()
+                .WithFullName("John Doe")
+                .WithDateOfBirth("1988-11-02")
+                .Build();
+
+            ResourceCreationContainer container =
+                new ResourceCreationContainerBuilder()
+                .WithApplicantProfile(applicantProfile)
+                .Build();
+
+            Assert.AreEqual(applicantProfile, container.ApplicantProfile);
+            Assert.AreEqual("John Doe", container.ApplicantProfile.FullName);
+            Assert.AreEqual("1988-11-02", container.ApplicantProfile.DateOfBirth);
+        }
+
+        [TestMethod]
+        public void ShouldCorrectlySerializeApplicantProfile()
+        {
+            var address = new StructuredPostalAddressBuilder()
+                .WithAddressFormat(1)
+                .WithBuildingNumber("74")
+                .WithAddressLine1("AddressLine1")
+                .WithTownCity("CityName")
+                .WithPostalCode("E143RN")
+                .WithCountryIso("GBR")
+                .WithCountry("United Kingdom")
+                .Build();
+
+            var applicantProfile = new ApplicantProfileBuilder()
+                .WithFullName("John Doe")
+                .WithDateOfBirth("1988-11-02")
+                .WithNamePrefix("Mr")
+                .WithStructuredPostalAddress(address)
+                .Build();
+
+            ResourceCreationContainer container =
+                new ResourceCreationContainerBuilder()
+                .WithApplicantProfile(applicantProfile)
+                .Build();
+
+            string json = JsonConvert.SerializeObject(container);
+
+            Assert.IsTrue(json.Contains("\"applicant_profile\""));
+            Assert.IsTrue(json.Contains("\"full_name\":\"John Doe\""));
+            Assert.IsTrue(json.Contains("\"date_of_birth\":\"1988-11-02\""));
+            Assert.IsTrue(json.Contains("\"name_prefix\":\"Mr\""));
+            Assert.IsTrue(json.Contains("\"structured_postal_address\""));
+            Assert.IsTrue(json.Contains("\"building_number\":\"74\""));
+            Assert.IsTrue(json.Contains("\"country_iso\":\"GBR\""));
+        }
+
+        [TestMethod]
+        public void ShouldBuildWithNullApplicantProfile()
+        {
+            ResourceCreationContainer container =
+                new ResourceCreationContainerBuilder()
+                .Build();
+
+            Assert.IsNull(container.ApplicantProfile);
+        }
+    }
+}

--- a/test/Yoti.Auth.Tests/DocScan/Session/Create/SessionSpecificationBuilderTests.cs
+++ b/test/Yoti.Auth.Tests/DocScan/Session/Create/SessionSpecificationBuilderTests.cs
@@ -320,5 +320,62 @@ namespace Yoti.Auth.Tests.DocScan.Session.Create
 
             Assert.IsNull(sessionSpec.Subject);
         }
+
+        [TestMethod]
+        public void ShouldBuildWithResources()
+        {
+            var applicantProfile = new ApplicantProfileBuilder()
+                .WithFullName("John Doe")
+                .WithDateOfBirth("1988-11-02")
+                .Build();
+
+            ResourceCreationContainer resources =
+                new ResourceCreationContainerBuilder()
+                .WithApplicantProfile(applicantProfile)
+                .Build();
+
+            SessionSpecification sessionSpec =
+                new SessionSpecificationBuilder()
+                .WithResources(resources)
+                .Build();
+
+            Assert.AreEqual(resources, sessionSpec.Resources);
+            Assert.AreEqual("John Doe", sessionSpec.Resources.ApplicantProfile.FullName);
+        }
+
+        [TestMethod]
+        public void ShouldNotImplicitlySetAValueForResources()
+        {
+            SessionSpecification sessionSpec =
+                new SessionSpecificationBuilder()
+                .Build();
+
+            Assert.IsNull(sessionSpec.Resources);
+        }
+
+        [TestMethod]
+        public void ShouldCorrectlySerializeResources()
+        {
+            var applicantProfile = new ApplicantProfileBuilder()
+                .WithFullName("John Doe")
+                .WithDateOfBirth("1988-11-02")
+                .Build();
+
+            ResourceCreationContainer resources =
+                new ResourceCreationContainerBuilder()
+                .WithApplicantProfile(applicantProfile)
+                .Build();
+
+            SessionSpecification sessionSpec =
+                new SessionSpecificationBuilder()
+                .WithResources(resources)
+                .Build();
+
+            string json = JsonConvert.SerializeObject(sessionSpec);
+
+            Assert.IsTrue(json.Contains("\"resources\":{\"applicant_profile\":{"));
+            Assert.IsTrue(json.Contains("\"full_name\":\"John Doe\""));
+            Assert.IsTrue(json.Contains("\"date_of_birth\":\"1988-11-02\""));
+        }
     }
 }

--- a/test/Yoti.Auth.Tests/DocScan/Session/Create/StructuredPostalAddressBuilderTests.cs
+++ b/test/Yoti.Auth.Tests/DocScan/Session/Create/StructuredPostalAddressBuilderTests.cs
@@ -1,0 +1,118 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using Yoti.Auth.DocScan.Session.Create;
+
+namespace Yoti.Auth.Tests.DocScan.Session.Create
+{
+    [TestClass]
+    public class StructuredPostalAddressBuilderTests
+    {
+        [TestMethod]
+        public void ShouldBuildWithAddressFormat()
+        {
+            var address = new StructuredPostalAddressBuilder()
+                .WithAddressFormat(1)
+                .Build();
+
+            Assert.AreEqual(1, address.AddressFormat);
+        }
+
+        [TestMethod]
+        public void ShouldBuildWithBuildingNumber()
+        {
+            var address = new StructuredPostalAddressBuilder()
+                .WithBuildingNumber("74")
+                .Build();
+
+            Assert.AreEqual("74", address.BuildingNumber);
+        }
+
+        [TestMethod]
+        public void ShouldBuildWithAddressLine1()
+        {
+            var address = new StructuredPostalAddressBuilder()
+                .WithAddressLine1("AddressLine1")
+                .Build();
+
+            Assert.AreEqual("AddressLine1", address.AddressLine1);
+        }
+
+        [TestMethod]
+        public void ShouldBuildWithTownCity()
+        {
+            var address = new StructuredPostalAddressBuilder()
+                .WithTownCity("CityName")
+                .Build();
+
+            Assert.AreEqual("CityName", address.TownCity);
+        }
+
+        [TestMethod]
+        public void ShouldBuildWithPostalCode()
+        {
+            var address = new StructuredPostalAddressBuilder()
+                .WithPostalCode("E143RN")
+                .Build();
+
+            Assert.AreEqual("E143RN", address.PostalCode);
+        }
+
+        [TestMethod]
+        public void ShouldBuildWithCountryIso()
+        {
+            var address = new StructuredPostalAddressBuilder()
+                .WithCountryIso("GBR")
+                .Build();
+
+            Assert.AreEqual("GBR", address.CountryIso);
+        }
+
+        [TestMethod]
+        public void ShouldBuildWithCountry()
+        {
+            var address = new StructuredPostalAddressBuilder()
+                .WithCountry("United Kingdom")
+                .Build();
+
+            Assert.AreEqual("United Kingdom", address.Country);
+        }
+
+        [TestMethod]
+        public void ShouldBuildWithFormattedAddress()
+        {
+            var formattedAddress = "74\nAddressLine1\nCityName\nE143RN\nGBR";
+
+            var address = new StructuredPostalAddressBuilder()
+                .WithFormattedAddress(formattedAddress)
+                .Build();
+
+            Assert.AreEqual(formattedAddress, address.FormattedAddress);
+        }
+
+        [TestMethod]
+        public void ShouldCorrectlySerializeAllProperties()
+        {
+            var address = new StructuredPostalAddressBuilder()
+                .WithAddressFormat(1)
+                .WithBuildingNumber("74")
+                .WithAddressLine1("AddressLine1")
+                .WithTownCity("CityName")
+                .WithPostalCode("E143RN")
+                .WithCountryIso("GBR")
+                .WithCountry("United Kingdom")
+                .WithFormattedAddress("74\nAddressLine1\nCityName\nE143RN\nGBR")
+                .Build();
+
+            string json = JsonConvert.SerializeObject(address);
+
+            Assert.IsTrue(json.Contains("\"address_format\":1"));
+            Assert.IsTrue(json.Contains("\"building_number\":\"74\""));
+            Assert.IsTrue(json.Contains("\"address_line1\":\"AddressLine1\""));
+            Assert.IsTrue(json.Contains("\"town_city\":\"CityName\""));
+            Assert.IsTrue(json.Contains("\"postal_code\":\"E143RN\""));
+            Assert.IsTrue(json.Contains("\"country_iso\":\"GBR\""));
+            Assert.IsTrue(json.Contains("\"country\":\"United Kingdom\""));
+            Assert.IsTrue(json.Contains("\"formatted_address\""));
+        }
+    }
+}

--- a/test/Yoti.Auth.Tests/Yoti.Auth.Tests.csproj
+++ b/test/Yoti.Auth.Tests/Yoti.Auth.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Yoti.Auth.Tests</AssemblyName>
     <PackageId>Yoti.Auth.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>


### PR DESCRIPTION
# Add applicant profile support for Identity Profile sessions

## Summary

This PR implements the ability for Relying Businesses to supply an `applicant_profile` when creating Identity Profile sessions. The applicant profile is passed within a `resources` object in the session specification.

## Changes

- Added `ResourceCreationContainer` and `ResourceCreationContainerBuilder` for the `resources` wrapper
- Added `ApplicantProfile` and `ApplicantProfileBuilder` with support for:
  - `full_name`
  - `date_of_birth`
  - `name_prefix`
  - `structured_postal_address`
- Added `StructuredPostalAddress` and `StructuredPostalAddressBuilder` with all address fields
- Added `ApplicantProfileResourceResponse` for session retrieval
- Updated `ResourceContainer` to include `ApplicantProfiles` list
- Added example controller demonstrating usage

## Usage Example

```csharp
var structuredPostalAddress = new StructuredPostalAddressBuilder()
    .WithAddressFormat(1)
    .WithBuildingNumber("10")
    .WithAddressLine1("1 Some Street")
    .WithTownCity("Some Town")
    .WithPostalCode("SW1A 1AA")
    .WithCountryIso("GBR")
    .WithCountry("United Kingdom")
    .WithFormattedAddress("10, 1 Some Street, Some Town, SW1A 1AA")
    .Build();

var applicantProfile = new ApplicantProfileBuilder()
    .WithFullName("John Doe")
    .WithDateOfBirth("1990-01-15")
    .WithNamePrefix("Mr")
    .WithStructuredPostalAddress(structuredPostalAddress)
    .Build();

var resources = new ResourceCreationContainerBuilder()
    .WithApplicantProfile(applicantProfile)
    .Build();

var sessionSpec = new SessionSpecificationBuilder()
    .WithClientSessionTokenTtl(600)
    .WithResourcesTtl(90000)
    .WithUserTrackingId("some-user-tracking-id")
    .WithResources(resources)
    // ... other configuration
    .Build();