### PR TITLE
Fix broken `DigitalIdentityService`

### DIFF
--- a/src/Yoti.Auth/DigitalIdentity/DigitalIdentityService.cs
+++ b/src/Yoti.Auth/DigitalIdentity/DigitalIdentityService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
@@ -116,7 +116,7 @@ namespace Yoti.Auth.DigitalIdentity
                 .WithKeyPair(keyPair)
                 .WithBaseUri(apiUrl)
                 .WithHeader(yotiAuthId, sdkId)
-                .WithEndpoint(string.Format($"/v2/sessions/{0}/qr-codes", sessionId))
+                .WithEndpoint($"/v2/sessions/{sessionId}/qr-codes")
                 .WithQueryParam("appId", sdkId)
                 .WithHttpMethod(HttpMethod.Post)
                 .WithContent(body)
@@ -148,7 +148,7 @@ namespace Yoti.Auth.DigitalIdentity
                 .WithKeyPair(keyPair)
                 .WithBaseUri(apiUrl)
                 .WithHeader(yotiAuthId, sdkId)
-                .WithEndpoint(string.Format($"/v2/qr-codes/{0}", qrCodeId))
+                .WithEndpoint($"/v2/qr-codes/{qrCodeId}")
                 .WithQueryParam("appId", sdkId)
                 .WithHttpMethod(HttpMethod.Get)
                 .Build();


### PR DESCRIPTION
In SDK version `3.19.0`, a bug was introduced into `DigitalIdentityService` which caused it to incorrectly interpolate strings when generating URLs against the QR Code API, resulting in a path like:

`/v2/sessions/0/qr-codes`

The result is that `DigitalIdentityService` is completely non-functional without a patch.