### PR TITLE
SDK-2612: IDV - Support configuration for IDV shortened flow - dotnet

### DIFF
--- a/src/Yoti.Auth/Constants/DocScanConstants.cs
+++ b/src/Yoti.Auth/Constants/DocScanConstants.cs
@@ -74,5 +74,13 @@
         public const string Generic = "GENERIC";
 
         public const string VerifyShareCodeTask = "VERIFY_SHARE_CODE_TASK";
+
+        public const string IdDocumentEducation = "ID_DOCUMENT_EDUCATION";
+        public const string IdDocumentRequirements = "ID_DOCUMENT_REQUIREMENTS";
+        public const string SupplementaryDocumentEducation = "SUPPLEMENTARY_DOCUMENT_EDUCATION";
+        public const string ZoomLivenessEducation = "ZOOM_LIVENESS_EDUCATION";
+        public const string StaticLivenessEducation = "STATIC_LIVENESS_EDUCATION";
+        public const string FaceCaptureEducation = "FACE_CAPTURE_EDUCATION";
+        public const string FlowCompletion = "FLOW_COMPLETION";
     }
 }

--- a/src/Yoti.Auth/DocScan/Session/Create/SdkConfig.cs
+++ b/src/Yoti.Auth/DocScan/Session/Create/SdkConfig.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using System.Collections.Generic;
 
 namespace Yoti.Auth.DocScan.Session.Create
@@ -41,6 +41,14 @@ namespace Yoti.Auth.DocScan.Session.Create
         [JsonProperty(PropertyName = "attempts_configuration")]
         public AttemptsConfiguration AttemptsConfiguration { get; }
 
+        [JsonProperty(PropertyName = "suppressed_screens", NullValueHandling = NullValueHandling.Ignore)]
+        public List<string> SuppressedScreens { get; }
+
+        public bool ShouldSerializeSuppressedScreens()
+        {
+            return SuppressedScreens != null && SuppressedScreens.Count > 0;
+        }
+
         public SdkConfig(string allowedCaptureMethods,
                             string primaryColour,
                             string secondaryColour,
@@ -51,7 +59,8 @@ namespace Yoti.Auth.DocScan.Session.Create
                             string errorUrl,
                             string privacyPolicyUrl,
                             bool? allowHandoff = null,
-                            Dictionary<string, int> idDocumentTextDataExtractionRetriesConfig = null)
+                            Dictionary<string, int> idDocumentTextDataExtractionRetriesConfig = null,
+                            List<string> suppressedScreens = null)
         {
             AllowedCaptureMethods = allowedCaptureMethods;
             PrimaryColour = primaryColour;
@@ -70,6 +79,11 @@ namespace Yoti.Auth.DocScan.Session.Create
                 {
                     IdDocumentTextDataExtraction = idDocumentTextDataExtractionRetriesConfig
                 };
+            }
+
+            if (suppressedScreens != null)
+            {
+                SuppressedScreens = new List<string>(suppressedScreens);
             }
         }
     }

--- a/src/Yoti.Auth/DocScan/Session/Create/SdkConfigBuilder.cs
+++ b/src/Yoti.Auth/DocScan/Session/Create/SdkConfigBuilder.cs
@@ -16,6 +16,7 @@ namespace Yoti.Auth.DocScan.Session.Create
         private string _privacyPolicyUrl;
         private bool? _allowHandoff;
         private Dictionary<string, int> _idDocumentTextDataExtractionAttemptsConfig;
+        private List<string> _suppressedScreens;
 
         /// <summary>
         /// Sets the allowed capture method to "CAMERA"
@@ -237,6 +238,39 @@ namespace Yoti.Auth.DocScan.Session.Create
         }   
 
         /// <summary>
+        /// Sets the list of screens to be suppressed during the IDV flow.
+        /// </summary>
+        /// <remarks>
+        ///     <para>
+        ///         This replaces any previously configured suppressed screens.
+        ///     </para>
+        ///     <para>
+        ///         Valid values are defined in <see cref="DocScanConstants"/>, e.g. <see cref="DocScanConstants.IdDocumentEducation"/>.
+        ///     </para>
+        /// </remarks>
+        /// <param name="suppressedScreens">The list of screens to suppress</param>
+        /// <returns>The <see cref="SdkConfigBuilder"/></returns>
+        public SdkConfigBuilder WithSuppressedScreens(List<string> suppressedScreens)
+        {
+            _suppressedScreens = suppressedScreens == null ? null : new List<string>(suppressedScreens);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a single screen to the list of screens to be suppressed during the IDV flow.
+        /// </summary>
+        /// <param name="suppressedScreen">The screen to suppress</param>
+        /// <returns>The <see cref="SdkConfigBuilder"/></returns>
+        public SdkConfigBuilder WithSuppressedScreen(string suppressedScreen)
+        {
+            if (_suppressedScreens == null)
+                _suppressedScreens = new List<string>();
+
+            _suppressedScreens.Add(suppressedScreen);
+            return this;
+        }
+
+        /// <summary>
         /// Builds the <see cref="SdkConfig"/> based on values supplied to the builder
         /// </summary>
         /// <returns>The built <see cref="SdkConfig"/></returns>
@@ -253,7 +287,8 @@ namespace Yoti.Auth.DocScan.Session.Create
                 _errorUrl,
                 _privacyPolicyUrl,
                 _allowHandoff,
-                _idDocumentTextDataExtractionAttemptsConfig);
+                _idDocumentTextDataExtractionAttemptsConfig,
+                _suppressedScreens);
         }
     }
 }

--- a/test/Yoti.Auth.Tests/DocScan/Session/Create/SdkConfigBuilderTests.cs
+++ b/test/Yoti.Auth.Tests/DocScan/Session/Create/SdkConfigBuilderTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
 using System.Collections.Generic;
 using Yoti.Auth.Constants;
 using Yoti.Auth.DocScan.Session.Create;
@@ -208,6 +209,143 @@ namespace Yoti.Auth.Tests.DocScan.Session.Create
 
             Assert.AreEqual(1, sdkConfig.AttemptsConfiguration.IdDocumentTextDataExtraction.Count);
             CollectionAssert.Contains(sdkConfig.AttemptsConfiguration.IdDocumentTextDataExtraction, kvp);
+        }
+
+        [TestMethod]
+        public void ShouldBuildWithSuppressedScreens()
+        {
+            var screens = new List<string>
+            {
+                DocScanConstants.IdDocumentEducation,
+                DocScanConstants.FlowCompletion
+            };
+
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .WithSuppressedScreens(screens)
+                .Build();
+
+            CollectionAssert.AreEqual(screens, sdkConfig.SuppressedScreens);
+        }
+
+        [TestMethod]
+        public void ShouldBuildWithSuppressedScreenSingle()
+        {
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .WithSuppressedScreen(DocScanConstants.ZoomLivenessEducation)
+                .WithSuppressedScreen(DocScanConstants.FaceCaptureEducation)
+                .Build();
+
+            Assert.AreEqual(2, sdkConfig.SuppressedScreens.Count);
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, DocScanConstants.ZoomLivenessEducation);
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, DocScanConstants.FaceCaptureEducation);
+        }
+
+        [TestMethod]
+        public void SuppressedScreensShouldBeNullIfNotSet()
+        {
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .Build();
+
+            Assert.IsNull(sdkConfig.SuppressedScreens);
+        }
+
+        [TestMethod]
+        public void SuppressedScreensShouldBeOmittedFromJsonWhenEmpty()
+        {
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .WithSuppressedScreens(new List<string>())
+                .Build();
+
+            string json = JsonConvert.SerializeObject(sdkConfig);
+
+            Assert.IsFalse(json.Contains("suppressed_screens"));
+        }
+
+        [TestMethod]
+        public void SuppressedScreensShouldBeSerializedWhenSet()
+        {
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .WithSuppressedScreen(DocScanConstants.IdDocumentRequirements)
+                .Build();
+
+            string json = JsonConvert.SerializeObject(sdkConfig);
+
+            Assert.IsTrue(json.Contains("\"suppressed_screens\":[\"ID_DOCUMENT_REQUIREMENTS\"]"));
+        }
+
+        [TestMethod]
+        public void SuppressedScreensShouldBeOmittedFromJsonWhenNotSet()
+        {
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .Build();
+
+            string json = JsonConvert.SerializeObject(sdkConfig);
+
+            Assert.IsFalse(json.Contains("suppressed_screens"));
+        }
+
+        [TestMethod]
+        public void SuppressedScreensShouldDeserializeFromJson()
+        {
+            string json = "{\"suppressed_screens\":[\"ID_DOCUMENT_EDUCATION\",\"FLOW_COMPLETION\"]}";
+
+            SdkConfig sdkConfig = JsonConvert.DeserializeObject<SdkConfig>(json);
+
+            Assert.IsNotNull(sdkConfig.SuppressedScreens);
+            Assert.AreEqual(2, sdkConfig.SuppressedScreens.Count);
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, DocScanConstants.IdDocumentEducation);
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, DocScanConstants.FlowCompletion);
+        }
+
+        [TestMethod]
+        public void SuppressedScreensShouldBeNullWhenMissingFromJson()
+        {
+            string json = "{}";
+
+            SdkConfig sdkConfig = JsonConvert.DeserializeObject<SdkConfig>(json);
+
+            Assert.IsNull(sdkConfig.SuppressedScreens);
+        }
+
+        [TestMethod]
+        public void SuppressedScreensShouldHandleEmptyArrayFromJson()
+        {
+            string json = "{\"suppressed_screens\":[]}";
+
+            SdkConfig sdkConfig = JsonConvert.DeserializeObject<SdkConfig>(json);
+
+            Assert.IsNotNull(sdkConfig.SuppressedScreens);
+            Assert.AreEqual(0, sdkConfig.SuppressedScreens.Count);
+        }
+
+        [TestMethod]
+        public void SuppressedScreensShouldHandleUnknownValueFromJson()
+        {
+            string json = "{\"suppressed_screens\":[\"ID_DOCUMENT_EDUCATION\",\"SOMETHING_NEW\"]}";
+
+            SdkConfig sdkConfig = JsonConvert.DeserializeObject<SdkConfig>(json);
+
+            Assert.IsNotNull(sdkConfig.SuppressedScreens);
+            Assert.AreEqual(2, sdkConfig.SuppressedScreens.Count);
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, "SOMETHING_NEW");
+        }
+
+        [TestMethod]
+        public void ShouldReplaceSuppressedScreensWithNullWhenPassed()
+        {
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .WithSuppressedScreen(DocScanConstants.IdDocumentEducation)
+                .WithSuppressedScreens(null)
+                .Build();
+
+            Assert.IsNull(sdkConfig.SuppressedScreens);
         }
 
         [TestMethod]


### PR DESCRIPTION
## Summary
Adds support for configuring the IDV shortened flow by allowing consumers to suppress specific screens during the Doc Scan session. The `SdkConfigBuilder` now exposes `WithSuppressedScreens` / `WithSuppressedScreen` methods, and the resulting `SdkConfig` serializes a `suppressed_screens` array to the Doc Scan API. Seven screen identifier constants (e.g. `ID_DOCUMENT_EDUCATION`, `FLOW_COMPLETION`) are added to `DocScanConstants` for convenience.

## Changes
- `src/Yoti.Auth/Constants/DocScanConstants.cs`: Added seven new screen identifier constants — `IdDocumentEducation`, `IdDocumentRequirements`, `SupplementaryDocumentEducation`, `ZoomLivenessEducation`, `StaticLivenessEducation`, `FaceCaptureEducation`, `FlowCompletion`.
- `src/Yoti.Auth/DocScan/Session/Create/SdkConfig.cs`: Added `SuppressedScreens` property serialized as `suppressed_screens` (omitted when null/empty via `ShouldSerializeSuppressedScreens` and `NullValueHandling.Ignore`). Constructor accepts an optional `suppressedScreens` list and defensively copies it.
- `src/Yoti.Auth/DocScan/Session/Create/SdkConfigBuilder.cs`: Added `WithSuppressedScreens(List<string>)` (replaces existing list, null clears) and `WithSuppressedScreen(string)` (appends a single screen). `Build()` now passes the list through to `SdkConfig`.
- `test/Yoti.Auth.Tests/DocScan/Session/Create/SdkConfigBuilderTests.cs`: Added 11 unit tests covering list/single-screen setters, null handling, JSON serialization/omission, JSON deserialization (including empty and unknown values), and replacement semantics.

## QA Test Steps
1. **Setup**: Check out the branch, run `dotnet restore` and `dotnet build` on the solution.
2. **Unit tests**: Run `dotnet test test/Yoti.Auth.Tests/Yoti.Auth.Tests.csproj --filter "FullyQualifiedName~SdkConfigBuilderTests"` and confirm all `SuppressedScreens*` tests pass (11 new tests).
3. **Happy path — multiple screens via list**: In a sample app, build an `SdkConfig` using `new SdkConfigBuilder().WithSuppressedScreens(new List<string>{ DocScanConstants.IdDocumentEducation, DocScanConstants.FlowCompletion }).Build()`. Serialize it (`JsonConvert.SerializeObject`) and verify the payload contains `"suppressed_screens":["ID_DOCUMENT_EDUCATION","FLOW_COMPLETION"]`.
4. **Happy path — single screen accumulation**: Chain `.WithSuppressedScreen(DocScanConstants.ZoomLivenessEducation).WithSuppressedScreen(DocScanConstants.FaceCaptureEducation)` and confirm both values appear in the serialized array in order.
5. **Edge case — not set**: Build an `SdkConfig` without calling either suppressed-screen method; assert `SuppressedScreens` is `null` and the JSON payload contains no `suppressed_screens` key.
6. **Edge case — empty list**: Call `.WithSuppressedScreens(new List<string>())` and confirm the JSON omits `suppressed_screens` (guarded by `ShouldSerializeSuppressedScreens`).
7. **Edge case — null replacement**: Add a screen via `.WithSuppressedScreen(...)`, then call `.WithSuppressedScreens(null)` and confirm `SuppressedScreens` is cleared to `null`.
8. **Edge case — replacement semantics**: Call `.WithSuppressedScreens(listA)` then `.WithSuppressedScreens(listB)` and confirm only `listB`'s contents are present (replaces, does not merge).
9. **Deserialization**: Deserialize `{"suppressed_screens":["ID_DOCUMENT_EDUCATION","FLOW_COMPLETION"]}` into `SdkConfig` and verify the list contains both entries. Repeat with `{}` (expect null) and `{"suppressed_screens":[]}` (expect empty list).
10. **End-to-end against Doc Scan API** (if a test tenant is available): Create a Doc Scan session with `SuppressedScreens` set to a valid combination and confirm the backend accepts the request and the suppressed screens do not appear in the resulting IDV web flow.
11. **Regression**: Run the full `Yoti.Auth.Tests` suite (`dotnet test`) to confirm existing `SdkConfigBuilder`, `AttemptsConfiguration`, and Doc Scan session-creation tests still pass.
12. **Regression — defensive copy**: Pass a mutable list to `WithSuppressedScreens`, build the config, then mutate the original list; confirm `sdkConfig.SuppressedScreens` is unaffected (copy is taken in both the builder and `SdkConfig` constructor).

## Notes
- `suppressed_screens` is omitted from the serialized payload when null or empty, preserving backward compatibility for callers that don't configure it.
- `WithSuppressedScreens(null)` intentionally clears any previously added screens (including those added via `WithSuppressedScreen`); covered by `ShouldReplaceSuppressedScreensWithNullWhenPassed`.
- Screen identifier constants are string values matching the Doc Scan API spec; unknown/future values can still be passed through (e.g. via `WithSuppressedScreen("NEW_SCREEN")`) without an SDK update.
- No changes were made to session creation/request plumbing beyond `SdkConfig` — the existing serialization pipeline carries the new field through automatically.
- Files now end with a trailing newline (`SdkConfig.cs`, `SdkConfigBuilder.cs`, `DocScanConstants.cs`); BOM removed from `SdkConfig.cs`.

---

*Related Jira:* SDK-2612
*Auto-generated by n8n + Claude CLI*