### PR TITLE
SDK-2612: IDV - Support configuration for IDV shortened flow - dotnet

### DIFF
--- a/src/Yoti.Auth/Constants/DocScanConstants.cs
+++ b/src/Yoti.Auth/Constants/DocScanConstants.cs
@@ -74,5 +74,13 @@
         public const string Generic = "GENERIC";
 
         public const string VerifyShareCodeTask = "VERIFY_SHARE_CODE_TASK";
+
+        public const string IdDocumentEducation = "ID_DOCUMENT_EDUCATION";
+        public const string IdDocumentRequirements = "ID_DOCUMENT_REQUIREMENTS";
+        public const string SupplementaryDocumentEducation = "SUPPLEMENTARY_DOCUMENT_EDUCATION";
+        public const string ZoomLivenessEducation = "ZOOM_LIVENESS_EDUCATION";
+        public const string StaticLivenessEducation = "STATIC_LIVENESS_EDUCATION";
+        public const string FaceCaptureEducation = "FACE_CAPTURE_EDUCATION";
+        public const string FlowCompletion = "FLOW_COMPLETION";
     }
 }

--- a/src/Yoti.Auth/DocScan/Session/Create/SdkConfig.cs
+++ b/src/Yoti.Auth/DocScan/Session/Create/SdkConfig.cs
@@ -41,6 +41,12 @@ namespace Yoti.Auth.DocScan.Session.Create
         [JsonProperty(PropertyName = "attempts_configuration")]
         public AttemptsConfiguration AttemptsConfiguration { get; }
 
+        /// <summary>
+        /// The list of screens that should be omitted from the IDV flow
+        /// </summary>
+        [JsonProperty(PropertyName = "suppressed_screens", NullValueHandling = NullValueHandling.Ignore)]
+        public List<string> SuppressedScreens { get; }
+
         public SdkConfig(string allowedCaptureMethods,
                             string primaryColour,
                             string secondaryColour,
@@ -51,7 +57,8 @@ namespace Yoti.Auth.DocScan.Session.Create
                             string errorUrl,
                             string privacyPolicyUrl,
                             bool? allowHandoff = null,
-                            Dictionary<string, int> idDocumentTextDataExtractionRetriesConfig = null)
+                            Dictionary<string, int> idDocumentTextDataExtractionRetriesConfig = null,
+                            List<string> suppressedScreens = null)
         {
             AllowedCaptureMethods = allowedCaptureMethods;
             PrimaryColour = primaryColour;
@@ -63,6 +70,7 @@ namespace Yoti.Auth.DocScan.Session.Create
             ErrorUrl = errorUrl;
             PrivacyPolicyUrl = privacyPolicyUrl;
             AllowHandoff = allowHandoff;
+            SuppressedScreens = suppressedScreens;
 
             if (idDocumentTextDataExtractionRetriesConfig != null)
             {
@@ -71,6 +79,16 @@ namespace Yoti.Auth.DocScan.Session.Create
                     IdDocumentTextDataExtraction = idDocumentTextDataExtractionRetriesConfig
                 };
             }
+        }
+
+        /// <summary>
+        /// Returns the list of screens configured to be suppressed from the IDV flow.
+        /// Returns an empty list when no screens are configured.
+        /// </summary>
+        /// <returns>The list of suppressed screen identifiers, never null.</returns>
+        public List<string> GetSuppressedScreens()
+        {
+            return SuppressedScreens ?? new List<string>();
         }
     }
 }

--- a/src/Yoti.Auth/DocScan/Session/Create/SdkConfigBuilder.cs
+++ b/src/Yoti.Auth/DocScan/Session/Create/SdkConfigBuilder.cs
@@ -16,6 +16,7 @@ namespace Yoti.Auth.DocScan.Session.Create
         private string _privacyPolicyUrl;
         private bool? _allowHandoff;
         private Dictionary<string, int> _idDocumentTextDataExtractionAttemptsConfig;
+        private List<string> _suppressedScreens;
 
         /// <summary>
         /// Sets the allowed capture method to "CAMERA"
@@ -237,6 +238,45 @@ namespace Yoti.Auth.DocScan.Session.Create
         }   
 
         /// <summary>
+        ///     <para>
+        ///         Sets the list of screens that should be suppressed from the IDV flow
+        ///     </para>
+        ///     <para>
+        ///         Valid values are defined in <see cref="DocScanConstants"/>:
+        ///         <see cref="DocScanConstants.IdDocumentEducation"/>,
+        ///         <see cref="DocScanConstants.IdDocumentRequirements"/>,
+        ///         <see cref="DocScanConstants.SupplementaryDocumentEducation"/>,
+        ///         <see cref="DocScanConstants.ZoomLivenessEducation"/>,
+        ///         <see cref="DocScanConstants.StaticLivenessEducation"/>,
+        ///         <see cref="DocScanConstants.FaceCaptureEducation"/>,
+        ///         <see cref="DocScanConstants.FlowCompletion"/>.
+        ///     </para>
+        /// </summary>
+        /// <param name="suppressedScreens">The list of screens to suppress</param>
+        /// <returns>The <see cref="SdkConfigBuilder"/></returns>
+        public SdkConfigBuilder WithSuppressedScreens(List<string> suppressedScreens)
+        {
+            _suppressedScreens = suppressedScreens;
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a single screen to the list of screens to suppress from the IDV flow
+        /// </summary>
+        /// <param name="suppressedScreen">The screen identifier to suppress</param>
+        /// <returns>The <see cref="SdkConfigBuilder"/></returns>
+        public SdkConfigBuilder WithSuppressedScreen(string suppressedScreen)
+        {
+            if (_suppressedScreens == null)
+                _suppressedScreens = new List<string>();
+
+            if (!_suppressedScreens.Contains(suppressedScreen))
+                _suppressedScreens.Add(suppressedScreen);
+
+            return this;
+        }
+
+        /// <summary>
         /// Builds the <see cref="SdkConfig"/> based on values supplied to the builder
         /// </summary>
         /// <returns>The built <see cref="SdkConfig"/></returns>
@@ -253,7 +293,8 @@ namespace Yoti.Auth.DocScan.Session.Create
                 _errorUrl,
                 _privacyPolicyUrl,
                 _allowHandoff,
-                _idDocumentTextDataExtractionAttemptsConfig);
+                _idDocumentTextDataExtractionAttemptsConfig,
+                _suppressedScreens);
         }
     }
 }

--- a/test/Yoti.Auth.Tests/DocScan/Session/Create/SdkConfigBuilderTests.cs
+++ b/test/Yoti.Auth.Tests/DocScan/Session/Create/SdkConfigBuilderTests.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
 using Yoti.Auth.Constants;
 using Yoti.Auth.DocScan.Session.Create;
@@ -231,5 +233,154 @@ namespace Yoti.Auth.Tests.DocScan.Session.Create
             CollectionAssert.Contains(sdkConfig.AttemptsConfiguration.IdDocumentTextDataExtraction, kvpUsersChoiceOfCategory);
             CollectionAssert.Contains(sdkConfig.AttemptsConfiguration.IdDocumentTextDataExtraction, kvpGenericAttempts);
         }
+
+        [TestMethod]
+        public void SuppressedScreensShouldBeNullIfNotSet()
+        {
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .Build();
+
+            Assert.IsNull(sdkConfig.SuppressedScreens);
+        }
+
+        [TestMethod]
+        public void GetSuppressedScreensShouldReturnEmptyListIfNotSet()
+        {
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .Build();
+
+            List<string> result = sdkConfig.GetSuppressedScreens();
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(0, result.Count);
+        }
+
+        [TestMethod]
+        public void ShouldBuildWithSuppressedScreens()
+        {
+            var screens = new List<string>
+            {
+                DocScanConstants.IdDocumentEducation,
+                DocScanConstants.FlowCompletion
+            };
+
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .WithSuppressedScreens(screens)
+                .Build();
+
+            CollectionAssert.AreEqual(screens, sdkConfig.SuppressedScreens);
+            CollectionAssert.AreEqual(screens, sdkConfig.GetSuppressedScreens());
+        }
+
+        [TestMethod]
+        public void ShouldBuildWithAllValidSuppressedScreens()
+        {
+            var screens = new List<string>
+            {
+                DocScanConstants.IdDocumentEducation,
+                DocScanConstants.IdDocumentRequirements,
+                DocScanConstants.SupplementaryDocumentEducation,
+                DocScanConstants.ZoomLivenessEducation,
+                DocScanConstants.StaticLivenessEducation,
+                DocScanConstants.FaceCaptureEducation,
+                DocScanConstants.FlowCompletion
+            };
+
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .WithSuppressedScreens(screens)
+                .Build();
+
+            Assert.AreEqual(7, sdkConfig.SuppressedScreens.Count);
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, "ID_DOCUMENT_EDUCATION");
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, "ID_DOCUMENT_REQUIREMENTS");
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, "SUPPLEMENTARY_DOCUMENT_EDUCATION");
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, "ZOOM_LIVENESS_EDUCATION");
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, "STATIC_LIVENESS_EDUCATION");
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, "FACE_CAPTURE_EDUCATION");
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, "FLOW_COMPLETION");
+        }
+
+        [TestMethod]
+        public void ShouldBuildWithEmptySuppressedScreens()
+        {
+            var screens = new List<string>();
+
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .WithSuppressedScreens(screens)
+                .Build();
+
+            Assert.IsNotNull(sdkConfig.SuppressedScreens);
+            Assert.AreEqual(0, sdkConfig.SuppressedScreens.Count);
+            Assert.AreEqual(0, sdkConfig.GetSuppressedScreens().Count);
+        }
+
+        [TestMethod]
+        public void ShouldAddIndividualSuppressedScreen()
+        {
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .WithSuppressedScreen(DocScanConstants.IdDocumentEducation)
+                .WithSuppressedScreen(DocScanConstants.FlowCompletion)
+                .Build();
+
+            Assert.AreEqual(2, sdkConfig.SuppressedScreens.Count);
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, DocScanConstants.IdDocumentEducation);
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, DocScanConstants.FlowCompletion);
+        }
+
+        [TestMethod]
+        public void ShouldDeduplicateIndividualSuppressedScreens()
+        {
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .WithSuppressedScreen(DocScanConstants.IdDocumentEducation)
+                .WithSuppressedScreen(DocScanConstants.IdDocumentEducation)
+                .Build();
+
+            Assert.AreEqual(1, sdkConfig.SuppressedScreens.Count);
+        }
+
+        [TestMethod]
+        public void SerializedSdkConfigShouldIncludeSuppressedScreensWhenSet()
+        {
+            var screens = new List<string>
+            {
+                DocScanConstants.IdDocumentEducation,
+                DocScanConstants.FlowCompletion
+            };
+
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .WithSuppressedScreens(screens)
+                .Build();
+
+            string json = JsonConvert.SerializeObject(sdkConfig);
+            JObject parsed = JObject.Parse(json);
+
+            Assert.IsTrue(parsed.ContainsKey("suppressed_screens"));
+            JArray items = (JArray)parsed["suppressed_screens"];
+            Assert.AreEqual(2, items.Count);
+            Assert.AreEqual("ID_DOCUMENT_EDUCATION", items[0].ToString());
+            Assert.AreEqual("FLOW_COMPLETION", items[1].ToString());
+        }
+
+        [TestMethod]
+        public void SerializedSdkConfigShouldOmitSuppressedScreensWhenNotSet()
+        {
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .Build();
+
+            string json = JsonConvert.SerializeObject(sdkConfig);
+            JObject parsed = JObject.Parse(json);
+
+            Assert.IsFalse(parsed.ContainsKey("suppressed_screens"));
+        }
+
     }
 }


### PR DESCRIPTION
## Summary
Adds support for configuring the IDV shortened flow by allowing integrators to suppress specific screens from the IDV journey. A new `suppressed_screens` field is introduced on `SdkConfig`, along with builder methods and constants for the supported screen identifiers, enabling a more streamlined end-user experience.

## Changes
- **`DocScanConstants.cs`**: Added seven new screen identifier constants — `IdDocumentEducation`, `IdDocumentRequirements`, `SupplementaryDocumentEducation`, `ZoomLivenessEducation`, `StaticLivenessEducation`, `FaceCaptureEducation`, and `FlowCompletion`.
- **`SdkConfig.cs`**: Added new `SuppressedScreens` property serialized as `suppressed_screens` with `NullValueHandling.Ignore` so the field is omitted when unset. Extended the constructor with an optional `suppressedScreens` parameter and added a `GetSuppressedScreens()` helper returning an empty list when unset (never null).
- **`SdkConfigBuilder.cs`**: Added `WithSuppressedScreens(List<string>)` to set the full list, and `WithSuppressedScreen(string)` to add a single screen with built-in deduplication and lazy list initialization. Updated `Build()` to propagate the new value into `SdkConfig`.
- **`SdkConfigBuilderTests.cs`**: Added nine tests covering: default null behaviour, `GetSuppressedScreens()` empty-list fallback, building with the full list, building with all seven valid screen constants, building with an empty list, adding individual screens, deduplication of individual adds, and JSON serialization including/omitting the field appropriately.

## QA Test Steps
1. **Setup**: Check out the branch `websdk-auto/SDK-2612-dotnet-idv---support-configuration-for-idv-shortened-flow` and restore/build the solution (`dotnet build`).
2. **Run the new unit tests**: Execute `dotnet test --filter FullyQualifiedName~SdkConfigBuilderTests` and confirm all nine new `SuppressedScreens`-related tests pass alongside the existing suite.
3. **Happy path – full list**: Create a sample program that builds an `SdkConfig` using `new SdkConfigBuilder().WithSuppressedScreens(new List<string> { DocScanConstants.IdDocumentEducation, DocScanConstants.FlowCompletion }).Build()`. Serialize with `JsonConvert.SerializeObject` and verify the output contains `"suppressed_screens":["ID_DOCUMENT_EDUCATION","FLOW_COMPLETION"]`.
4. **Happy path – individual adds**: Build via `.WithSuppressedScreen(DocScanConstants.IdDocumentEducation).WithSuppressedScreen(DocScanConstants.FlowCompletion)` and confirm both entries appear in the serialized JSON.
5. **Deduplication**: Call `.WithSuppressedScreen(DocScanConstants.IdDocumentEducation)` twice and verify `sdkConfig.SuppressedScreens.Count == 1`.
6. **Field omission**: Build an `SdkConfig` without calling either new method and confirm the serialized JSON does **not** contain a `suppressed_screens` key (validates `NullValueHandling.Ignore`).
7. **GetSuppressedScreens fallback**: On an `SdkConfig` built without suppressed screens, confirm `GetSuppressedScreens()` returns a non-null empty list.
8. **All seven constants**: Build with all seven new `DocScanConstants` values and confirm each serializes to its expected uppercase snake_case string (`ID_DOCUMENT_EDUCATION`, `ID_DOCUMENT_REQUIREMENTS`, `SUPPLEMENTARY_DOCUMENT_EDUCATION`, `ZOOM_LIVENESS_EDUCATION`, `STATIC_LIVENESS_EDUCATION`, `FACE_CAPTURE_EDUCATION`, `FLOW_COMPLETION`).
9. **End-to-end regression (IDV backend)**: Using a test client ID and a Create Session request that embeds the built `SdkConfig`, POST to the Doc Scan / IDV `/sessions` endpoint. Confirm the session is created successfully (HTTP 201) and the suppressed screens are honored when launching the IDV web SDK flow with the returned session token.
10. **Existing behaviour regression**: Verify existing tests covering `AllowedCaptureMethods`, colours, fonts, URLs, `AllowHandoff`, and `AttemptsConfiguration` still pass unchanged — the new optional constructor parameter must not break existing call sites.

## Notes
- The `suppressed_screens` field uses `NullValueHandling.Ignore` so the JSON payload remains backwards compatible for integrators not using the shortened flow.
- `WithSuppressedScreen` (singular) deduplicates silently; `WithSuppressedScreens` (plural) replaces the full list without deduplication — callers passing duplicates via the list overload retain them. This matches the pattern used in other SDKs for this feature.
- `GetSuppressedScreens()` never returns null, making consumer code safer; the `SuppressedScreens` property itself remains nullable to preserve the JSON omission behaviour.
- No validation is performed on screen identifier strings against the known constants — the server is the source of truth for valid values, consistent with how other Doc Scan string-enum fields are handled in this SDK.
- No public API was broken: the new constructor parameter is optional and defaults to `null`.

---

*Related Jira:* SDK-2612
*Auto-generated by n8n + Claude CLI*