### PR TITLE
SDK-2612: IDV - Support configuration for IDV shortened flow - dotnet

### DIFF
--- a/src/Yoti.Auth/Constants/DocScanConstants.cs
+++ b/src/Yoti.Auth/Constants/DocScanConstants.cs
@@ -74,5 +74,13 @@
         public const string Generic = "GENERIC";
 
         public const string VerifyShareCodeTask = "VERIFY_SHARE_CODE_TASK";
+
+        public const string IdDocumentEducation = "ID_DOCUMENT_EDUCATION";
+        public const string IdDocumentRequirements = "ID_DOCUMENT_REQUIREMENTS";
+        public const string SupplementaryDocumentEducation = "SUPPLEMENTARY_DOCUMENT_EDUCATION";
+        public const string ZoomLivenessEducation = "ZOOM_LIVENESS_EDUCATION";
+        public const string StaticLivenessEducation = "STATIC_LIVENESS_EDUCATION";
+        public const string FaceCaptureEducation = "FACE_CAPTURE_EDUCATION";
+        public const string FlowCompletion = "FLOW_COMPLETION";
     }
 }

--- a/src/Yoti.Auth/DocScan/Session/Create/SdkConfig.cs
+++ b/src/Yoti.Auth/DocScan/Session/Create/SdkConfig.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using System.Collections.Generic;
 
 namespace Yoti.Auth.DocScan.Session.Create
@@ -41,6 +41,9 @@ namespace Yoti.Auth.DocScan.Session.Create
         [JsonProperty(PropertyName = "attempts_configuration")]
         public AttemptsConfiguration AttemptsConfiguration { get; }
 
+        [JsonProperty(PropertyName = "suppressed_screens", NullValueHandling = NullValueHandling.Ignore)]
+        public List<string> SuppressedScreens { get; }
+
         public SdkConfig(string allowedCaptureMethods,
                             string primaryColour,
                             string secondaryColour,
@@ -51,7 +54,8 @@ namespace Yoti.Auth.DocScan.Session.Create
                             string errorUrl,
                             string privacyPolicyUrl,
                             bool? allowHandoff = null,
-                            Dictionary<string, int> idDocumentTextDataExtractionRetriesConfig = null)
+                            Dictionary<string, int> idDocumentTextDataExtractionRetriesConfig = null,
+                            List<string> suppressedScreens = null)
         {
             AllowedCaptureMethods = allowedCaptureMethods;
             PrimaryColour = primaryColour;
@@ -63,6 +67,7 @@ namespace Yoti.Auth.DocScan.Session.Create
             ErrorUrl = errorUrl;
             PrivacyPolicyUrl = privacyPolicyUrl;
             AllowHandoff = allowHandoff;
+            SuppressedScreens = suppressedScreens;
 
             if (idDocumentTextDataExtractionRetriesConfig != null)
             {

--- a/src/Yoti.Auth/DocScan/Session/Create/SdkConfigBuilder.cs
+++ b/src/Yoti.Auth/DocScan/Session/Create/SdkConfigBuilder.cs
@@ -16,6 +16,7 @@ namespace Yoti.Auth.DocScan.Session.Create
         private string _privacyPolicyUrl;
         private bool? _allowHandoff;
         private Dictionary<string, int> _idDocumentTextDataExtractionAttemptsConfig;
+        private List<string> _suppressedScreens;
 
         /// <summary>
         /// Sets the allowed capture method to "CAMERA"
@@ -237,6 +238,40 @@ namespace Yoti.Auth.DocScan.Session.Create
         }   
 
         /// <summary>
+        /// Sets the list of screens to be suppressed from the IDV flow
+        /// </summary>
+        /// <remarks>
+        ///     <para>
+        ///         Valid screen identifiers are defined in <see cref="DocScanConstants"/>
+        ///         (e.g. <see cref="DocScanConstants.IdDocumentEducation"/>, <see cref="DocScanConstants.FlowCompletion"/>).
+        ///     </para>
+        ///     <para>
+        ///         Unrecognised screen names are still sent to the backend; the web/native client is responsible for ignoring them.
+        ///     </para>
+        /// </remarks>
+        /// <param name="suppressedScreens">The list of screen identifiers to suppress</param>
+        /// <returns>The <see cref="SdkConfigBuilder"/></returns>
+        public SdkConfigBuilder WithSuppressedScreens(List<string> suppressedScreens)
+        {
+            _suppressedScreens = suppressedScreens;
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a single screen identifier to the list of suppressed screens
+        /// </summary>
+        /// <param name="suppressedScreen">The screen identifier to suppress (see <see cref="DocScanConstants"/>)</param>
+        /// <returns>The <see cref="SdkConfigBuilder"/></returns>
+        public SdkConfigBuilder WithSuppressedScreen(string suppressedScreen)
+        {
+            if (_suppressedScreens == null)
+                _suppressedScreens = new List<string>();
+
+            _suppressedScreens.Add(suppressedScreen);
+            return this;
+        }
+
+        /// <summary>
         /// Builds the <see cref="SdkConfig"/> based on values supplied to the builder
         /// </summary>
         /// <returns>The built <see cref="SdkConfig"/></returns>
@@ -253,7 +288,8 @@ namespace Yoti.Auth.DocScan.Session.Create
                 _errorUrl,
                 _privacyPolicyUrl,
                 _allowHandoff,
-                _idDocumentTextDataExtractionAttemptsConfig);
+                _idDocumentTextDataExtractionAttemptsConfig,
+                _suppressedScreens);
         }
     }
 }

--- a/test/Yoti.Auth.Tests/DocScan/Session/Create/SdkConfigBuilderTests.cs
+++ b/test/Yoti.Auth.Tests/DocScan/Session/Create/SdkConfigBuilderTests.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
 using Yoti.Auth.Constants;
 using Yoti.Auth.DocScan.Session.Create;
@@ -208,6 +210,161 @@ namespace Yoti.Auth.Tests.DocScan.Session.Create
 
             Assert.AreEqual(1, sdkConfig.AttemptsConfiguration.IdDocumentTextDataExtraction.Count);
             CollectionAssert.Contains(sdkConfig.AttemptsConfiguration.IdDocumentTextDataExtraction, kvp);
+        }
+
+        [TestMethod]
+        public void SuppressedScreensShouldBeNullIfNotSet()
+        {
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .Build();
+
+            Assert.IsNull(sdkConfig.SuppressedScreens);
+        }
+
+        [TestMethod]
+        public void SuppressedScreensShouldNotBeSerialisedWhenNull()
+        {
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .Build();
+
+            string json = JsonConvert.SerializeObject(sdkConfig);
+            JObject parsed = JObject.Parse(json);
+
+            Assert.IsFalse(parsed.ContainsKey("suppressed_screens"));
+        }
+
+        [TestMethod]
+        public void ShouldBuildWithSuppressedScreensList()
+        {
+            var suppressed = new List<string>
+            {
+                DocScanConstants.IdDocumentEducation,
+                DocScanConstants.FlowCompletion
+            };
+
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .WithSuppressedScreens(suppressed)
+                .Build();
+
+            CollectionAssert.AreEqual(suppressed, sdkConfig.SuppressedScreens);
+        }
+
+        [TestMethod]
+        public void ShouldBuildWithSuppressedScreensContainingAllScreenValues()
+        {
+            var suppressed = new List<string>
+            {
+                DocScanConstants.IdDocumentEducation,
+                DocScanConstants.IdDocumentRequirements,
+                DocScanConstants.SupplementaryDocumentEducation,
+                DocScanConstants.ZoomLivenessEducation,
+                DocScanConstants.StaticLivenessEducation,
+                DocScanConstants.FaceCaptureEducation,
+                DocScanConstants.FlowCompletion
+            };
+
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .WithSuppressedScreens(suppressed)
+                .Build();
+
+            Assert.AreEqual(7, sdkConfig.SuppressedScreens.Count);
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, "ID_DOCUMENT_EDUCATION");
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, "ID_DOCUMENT_REQUIREMENTS");
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, "SUPPLEMENTARY_DOCUMENT_EDUCATION");
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, "ZOOM_LIVENESS_EDUCATION");
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, "STATIC_LIVENESS_EDUCATION");
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, "FACE_CAPTURE_EDUCATION");
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, "FLOW_COMPLETION");
+        }
+
+        [TestMethod]
+        public void ShouldBuildWithSingleSuppressedScreen()
+        {
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .WithSuppressedScreen(DocScanConstants.FlowCompletion)
+                .Build();
+
+            Assert.AreEqual(1, sdkConfig.SuppressedScreens.Count);
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, "FLOW_COMPLETION");
+        }
+
+        [TestMethod]
+        public void ShouldBuildByAccumulatingMultipleSuppressedScreens()
+        {
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .WithSuppressedScreen(DocScanConstants.IdDocumentEducation)
+                .WithSuppressedScreen(DocScanConstants.ZoomLivenessEducation)
+                .WithSuppressedScreen(DocScanConstants.FlowCompletion)
+                .Build();
+
+            Assert.AreEqual(3, sdkConfig.SuppressedScreens.Count);
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, "ID_DOCUMENT_EDUCATION");
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, "ZOOM_LIVENESS_EDUCATION");
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, "FLOW_COMPLETION");
+        }
+
+        [TestMethod]
+        public void SuppressedScreensShouldBeSerialisedToCorrectJsonKey()
+        {
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .WithSuppressedScreen(DocScanConstants.FlowCompletion)
+                .Build();
+
+            string json = JsonConvert.SerializeObject(sdkConfig);
+            JObject parsed = JObject.Parse(json);
+
+            Assert.IsTrue(parsed.ContainsKey("suppressed_screens"));
+            JArray array = (JArray)parsed["suppressed_screens"];
+            Assert.AreEqual(1, array.Count);
+            Assert.AreEqual("FLOW_COMPLETION", array[0].ToString());
+        }
+
+        [TestMethod]
+        public void SuppressedScreensShouldPreserveUnknownValues()
+        {
+            var suppressed = new List<string> { "SOMETHING_UNRECOGNISED" };
+
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .WithSuppressedScreens(suppressed)
+                .Build();
+
+            Assert.AreEqual(1, sdkConfig.SuppressedScreens.Count);
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, "SOMETHING_UNRECOGNISED");
+        }
+
+        [TestMethod]
+        public void SuppressedScreensShouldAllowEmptyList()
+        {
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .WithSuppressedScreens(new List<string>())
+                .Build();
+
+            Assert.IsNotNull(sdkConfig.SuppressedScreens);
+            Assert.AreEqual(0, sdkConfig.SuppressedScreens.Count);
+        }
+
+        [TestMethod]
+        public void ExistingSdkConfigPropertiesShouldBeUnaffectedBySuppressedScreens()
+        {
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .WithAllowsCamera()
+                .WithPrimaryColour("#ffffff")
+                .WithSuppressedScreen(DocScanConstants.FlowCompletion)
+                .Build();
+
+            Assert.AreEqual("CAMERA", sdkConfig.AllowedCaptureMethods);
+            Assert.AreEqual("#ffffff", sdkConfig.PrimaryColour);
+            Assert.AreEqual(1, sdkConfig.SuppressedScreens.Count);
         }
 
         [TestMethod]


### PR DESCRIPTION
## Summary
Adds support for configuring the IDV shortened flow by allowing integrators to suppress specific screens (e.g. education and flow completion screens) in the Yoti Doc Scan SDK. A new `suppressed_screens` field is exposed on `SdkConfig`, populated via two new builder methods, and serialised as a JSON array that is omitted when unset.

## Changes
- `src/Yoti.Auth/Constants/DocScanConstants.cs`: Added seven screen-identifier constants (`IdDocumentEducation`, `IdDocumentRequirements`, `SupplementaryDocumentEducation`, `ZoomLivenessEducation`, `StaticLivenessEducation`, `FaceCaptureEducation`, `FlowCompletion`) to represent the suppressible IDV flow screens.
- `src/Yoti.Auth/DocScan/Session/Create/SdkConfig.cs`: Added new `SuppressedScreens` property serialised as `suppressed_screens` with `NullValueHandling.Ignore`, plus a new optional constructor parameter.
- `src/Yoti.Auth/DocScan/Session/Create/SdkConfigBuilder.cs`: Added `WithSuppressedScreens(List<string>)` to set the full list and `WithSuppressedScreen(string)` to incrementally append a single identifier; `Build()` now propagates the value.
- `test/Yoti.Auth.Tests/DocScan/Session/Create/SdkConfigBuilderTests.cs`: Added 10 unit tests covering default null behaviour, JSON omission when null, list/single/accumulated builder paths, all-screens coverage, unknown-value preservation, empty-list handling, correct JSON key/shape, and non-interference with existing properties.

## QA Test Steps
1. **Setup**: Check out branch `websdk-auto/SDK-2612-dotnet-idv---support-configuration-for-idv-shortened-flow` and restore dependencies (`dotnet restore`).
2. **Build**: Run `dotnet build` from the repo root and confirm the solution compiles with no new warnings.
3. **Unit tests (new)**: Run `dotnet test --filter "FullyQualifiedName~SdkConfigBuilderTests"` and verify all tests pass, specifically the 10 new `SuppressedScreens*` / `ShouldBuildWith*SuppressedScreen*` tests.
4. **Unit tests (regression)**: Run the full suite `dotnet test` and confirm no existing tests break (`AttemptsConfiguration*`, capture method, colours, URLs, `AllowHandoff`).
5. **Builder — list API**:
   - Instantiate `new SdkConfigBuilder().WithSuppressedScreens(new List<string> { DocScanConstants.IdDocumentEducation, DocScanConstants.FlowCompletion }).Build()`.
   - Serialise with `JsonConvert.SerializeObject(...)` and verify output contains `"suppressed_screens":["ID_DOCUMENT_EDUCATION","FLOW_COMPLETION"]`.
6. **Builder — single-add API (accumulation)**:
   - Call `.WithSuppressedScreen(DocScanConstants.IdDocumentEducation).WithSuppressedScreen(DocScanConstants.ZoomLivenessEducation).WithSuppressedScreen(DocScanConstants.FlowCompletion)` and confirm all three values are present in order.
7. **Default / null behaviour**: Build a config without calling the new methods; confirm `SuppressedScreens` is `null` and the serialised JSON does **not** contain the `suppressed_screens` key.
8. **Empty list**: Build with `.WithSuppressedScreens(new List<string>())`; confirm `SuppressedScreens` is a non-null empty list and serialises as `"suppressed_screens":[]`.
9. **Unknown values**: Pass an arbitrary string (e.g. `"SOMETHING_UNRECOGNISED"`); verify it is preserved as-is in the payload (backend / client is responsible for filtering).
10. **Regression — end-to-end session creation**: Using the sample/examples project, create a Doc Scan session including `WithSuppressedScreen(DocScanConstants.FlowCompletion)` alongside existing fields (camera, colours, URLs, attempts config); verify the outbound request body contains `suppressed_screens` at the correct location inside the `sdk_config` object and that an IDV session is created successfully.
11. **Regression — interaction**: Confirm a builder chain that combines `WithAllowsCamera()`, `WithPrimaryColour("#ffffff")`, and `WithSuppressedScreen(...)` populates all three properties correctly (`ExistingSdkConfigPropertiesShouldBeUnaffectedBySuppressedScreens`).

## Notes
- `suppressed_screens` uses `NullValueHandling.Ignore`, so the field is omitted from the serialised payload when not configured — preserving backwards compatibility with existing integrations and backend expectations.
- The SDK intentionally does not validate screen identifiers against the `DocScanConstants` allowlist; unrecognised values are forwarded verbatim, and the web/native client is responsible for ignoring them. This matches the contract documented on `WithSuppressedScreens` and is covered by `SuppressedScreensShouldPreserveUnknownValues`.
- `WithSuppressedScreens(List<string>)` replaces any previously accumulated list, while `WithSuppressedScreen(string)` lazily initialises and appends — mixing both on the same builder will behave accordingly (setter wins if called last).
- No changes were required to the HTTP request layer — `SdkConfig` is already serialised as part of the session creation payload.
- Incidental cleanup: removed a stray BOM/trailing-newline inconsistency in `SdkConfig.cs`; no functional impact.

---

*Related Jira:* SDK-2612
*Auto-generated by n8n + Claude CLI*