### PR TITLE
SDK-2612: IDV - Support configuration for IDV shortened flow - dotnet

### DIFF
--- a/src/Yoti.Auth/Constants/DocScanConstants.cs
+++ b/src/Yoti.Auth/Constants/DocScanConstants.cs
@@ -74,5 +74,13 @@
         public const string Generic = "GENERIC";
 
         public const string VerifyShareCodeTask = "VERIFY_SHARE_CODE_TASK";
+
+        public const string IdDocumentEducation = "ID_DOCUMENT_EDUCATION";
+        public const string IdDocumentRequirements = "ID_DOCUMENT_REQUIREMENTS";
+        public const string SupplementaryDocumentEducation = "SUPPLEMENTARY_DOCUMENT_EDUCATION";
+        public const string ZoomLivenessEducation = "ZOOM_LIVENESS_EDUCATION";
+        public const string StaticLivenessEducation = "STATIC_LIVENESS_EDUCATION";
+        public const string FaceCaptureEducation = "FACE_CAPTURE_EDUCATION";
+        public const string FlowCompletion = "FLOW_COMPLETION";
     }
 }

--- a/src/Yoti.Auth/DocScan/Session/Create/SdkConfig.cs
+++ b/src/Yoti.Auth/DocScan/Session/Create/SdkConfig.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using System.Collections.Generic;
 
 namespace Yoti.Auth.DocScan.Session.Create
@@ -41,6 +41,9 @@ namespace Yoti.Auth.DocScan.Session.Create
         [JsonProperty(PropertyName = "attempts_configuration")]
         public AttemptsConfiguration AttemptsConfiguration { get; }
 
+        [JsonProperty(PropertyName = "suppressed_screens", NullValueHandling = NullValueHandling.Ignore)]
+        public List<string> SuppressedScreens { get; }
+
         public SdkConfig(string allowedCaptureMethods,
                             string primaryColour,
                             string secondaryColour,
@@ -51,7 +54,8 @@ namespace Yoti.Auth.DocScan.Session.Create
                             string errorUrl,
                             string privacyPolicyUrl,
                             bool? allowHandoff = null,
-                            Dictionary<string, int> idDocumentTextDataExtractionRetriesConfig = null)
+                            Dictionary<string, int> idDocumentTextDataExtractionRetriesConfig = null,
+                            List<string> suppressedScreens = null)
         {
             AllowedCaptureMethods = allowedCaptureMethods;
             PrimaryColour = primaryColour;
@@ -71,6 +75,8 @@ namespace Yoti.Auth.DocScan.Session.Create
                     IdDocumentTextDataExtraction = idDocumentTextDataExtractionRetriesConfig
                 };
             }
+
+            SuppressedScreens = suppressedScreens;
         }
     }
 }

--- a/src/Yoti.Auth/DocScan/Session/Create/SdkConfigBuilder.cs
+++ b/src/Yoti.Auth/DocScan/Session/Create/SdkConfigBuilder.cs
@@ -16,6 +16,18 @@ namespace Yoti.Auth.DocScan.Session.Create
         private string _privacyPolicyUrl;
         private bool? _allowHandoff;
         private Dictionary<string, int> _idDocumentTextDataExtractionAttemptsConfig;
+        private List<string> _suppressedScreens;
+
+        private static readonly HashSet<string> _validSuppressedScreens = new HashSet<string>
+        {
+            DocScanConstants.IdDocumentEducation,
+            DocScanConstants.IdDocumentRequirements,
+            DocScanConstants.SupplementaryDocumentEducation,
+            DocScanConstants.ZoomLivenessEducation,
+            DocScanConstants.StaticLivenessEducation,
+            DocScanConstants.FaceCaptureEducation,
+            DocScanConstants.FlowCompletion
+        };
 
         /// <summary>
         /// Sets the allowed capture method to "CAMERA"
@@ -234,7 +246,60 @@ namespace Yoti.Auth.DocScan.Session.Create
         {
             WithIdDocumentTextExtractionCategoryAttempts(DocScanConstants.Generic, genericAttempts);
             return this;
-        }   
+        }
+
+        /// <summary>
+        /// Adds a screen identifier to be suppressed (omitted) by the web/native client during the IDV flow
+        /// </summary>
+        /// <remarks>
+        ///     <para>
+        ///         Unknown/unsupported identifiers are ignored so that new backend values don't cause failures
+        ///     </para>
+        /// </remarks>
+        /// <param name="suppressedScreen">The screen identifier to suppress (e.g. <see cref="DocScanConstants.IdDocumentEducation"/>)</param>
+        /// <returns>The <see cref="SdkConfigBuilder"/></returns>
+        public SdkConfigBuilder WithSuppressedScreen(string suppressedScreen)
+        {
+            if (string.IsNullOrEmpty(suppressedScreen) || !_validSuppressedScreens.Contains(suppressedScreen))
+                return this;
+
+            if (_suppressedScreens == null)
+                _suppressedScreens = new List<string>();
+
+            if (!_suppressedScreens.Contains(suppressedScreen))
+                _suppressedScreens.Add(suppressedScreen);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the full list of screen identifiers to be suppressed by the web/native client during the IDV flow
+        /// </summary>
+        /// <remarks>
+        ///     <para>
+        ///         Unknown/unsupported identifiers are ignored so that new backend values don't cause failures
+        ///     </para>
+        ///     <para>
+        ///         Passing <c>null</c> clears any previously configured suppressed screens
+        ///     </para>
+        /// </remarks>
+        /// <param name="suppressedScreens">The screen identifiers to suppress</param>
+        /// <returns>The <see cref="SdkConfigBuilder"/></returns>
+        public SdkConfigBuilder WithSuppressedScreens(List<string> suppressedScreens)
+        {
+            if (suppressedScreens == null)
+            {
+                _suppressedScreens = null;
+                return this;
+            }
+
+            _suppressedScreens = null;
+            foreach (string suppressedScreen in suppressedScreens)
+            {
+                WithSuppressedScreen(suppressedScreen);
+            }
+            return this;
+        }
 
         /// <summary>
         /// Builds the <see cref="SdkConfig"/> based on values supplied to the builder
@@ -253,7 +318,8 @@ namespace Yoti.Auth.DocScan.Session.Create
                 _errorUrl,
                 _privacyPolicyUrl,
                 _allowHandoff,
-                _idDocumentTextDataExtractionAttemptsConfig);
+                _idDocumentTextDataExtractionAttemptsConfig,
+                _suppressedScreens);
         }
     }
 }

--- a/test/Yoti.Auth.Tests/DocScan/Session/Create/SdkConfigBuilderTests.cs
+++ b/test/Yoti.Auth.Tests/DocScan/Session/Create/SdkConfigBuilderTests.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
 using Yoti.Auth.Constants;
 using Yoti.Auth.DocScan.Session.Create;
@@ -230,6 +232,231 @@ namespace Yoti.Auth.Tests.DocScan.Session.Create
             CollectionAssert.Contains(sdkConfig.AttemptsConfiguration.IdDocumentTextDataExtraction, kvpReclassificationAttempts);
             CollectionAssert.Contains(sdkConfig.AttemptsConfiguration.IdDocumentTextDataExtraction, kvpUsersChoiceOfCategory);
             CollectionAssert.Contains(sdkConfig.AttemptsConfiguration.IdDocumentTextDataExtraction, kvpGenericAttempts);
+        }
+
+        [TestMethod]
+        public void SuppressedScreensShouldBeNullIfNotSet()
+        {
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .Build();
+
+            Assert.IsNull(sdkConfig.SuppressedScreens);
+        }
+
+        [TestMethod]
+        public void SuppressedScreensShouldBeOmittedFromJsonIfNotSet()
+        {
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .Build();
+
+            string json = JsonConvert.SerializeObject(sdkConfig);
+            JObject parsed = JObject.Parse(json);
+
+            Assert.IsFalse(parsed.ContainsKey("suppressed_screens"));
+        }
+
+        [TestMethod]
+        public void ShouldBuildWithSingleSuppressedScreen()
+        {
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .WithSuppressedScreen(DocScanConstants.IdDocumentEducation)
+                .Build();
+
+            Assert.IsNotNull(sdkConfig.SuppressedScreens);
+            Assert.AreEqual(1, sdkConfig.SuppressedScreens.Count);
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, DocScanConstants.IdDocumentEducation);
+        }
+
+        [TestMethod]
+        public void ShouldBuildWithAllValidSuppressedScreens()
+        {
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .WithSuppressedScreen(DocScanConstants.IdDocumentEducation)
+                .WithSuppressedScreen(DocScanConstants.IdDocumentRequirements)
+                .WithSuppressedScreen(DocScanConstants.SupplementaryDocumentEducation)
+                .WithSuppressedScreen(DocScanConstants.ZoomLivenessEducation)
+                .WithSuppressedScreen(DocScanConstants.StaticLivenessEducation)
+                .WithSuppressedScreen(DocScanConstants.FaceCaptureEducation)
+                .WithSuppressedScreen(DocScanConstants.FlowCompletion)
+                .Build();
+
+            Assert.AreEqual(7, sdkConfig.SuppressedScreens.Count);
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, "ID_DOCUMENT_EDUCATION");
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, "ID_DOCUMENT_REQUIREMENTS");
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, "SUPPLEMENTARY_DOCUMENT_EDUCATION");
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, "ZOOM_LIVENESS_EDUCATION");
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, "STATIC_LIVENESS_EDUCATION");
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, "FACE_CAPTURE_EDUCATION");
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, "FLOW_COMPLETION");
+        }
+
+        [TestMethod]
+        public void ShouldIgnoreUnknownSuppressedScreenIdentifier()
+        {
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .WithSuppressedScreen("SOMETHING_UNKNOWN")
+                .Build();
+
+            Assert.IsNull(sdkConfig.SuppressedScreens);
+        }
+
+        [TestMethod]
+        public void ShouldIgnoreNullOrEmptySuppressedScreenIdentifier()
+        {
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .WithSuppressedScreen(null)
+                .WithSuppressedScreen(string.Empty)
+                .Build();
+
+            Assert.IsNull(sdkConfig.SuppressedScreens);
+        }
+
+        [TestMethod]
+        public void ShouldDeduplicateSuppressedScreens()
+        {
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .WithSuppressedScreen(DocScanConstants.FlowCompletion)
+                .WithSuppressedScreen(DocScanConstants.FlowCompletion)
+                .Build();
+
+            Assert.AreEqual(1, sdkConfig.SuppressedScreens.Count);
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, DocScanConstants.FlowCompletion);
+        }
+
+        [TestMethod]
+        public void ShouldBuildWithSuppressedScreensList()
+        {
+            List<string> screens = new List<string>
+            {
+                DocScanConstants.IdDocumentEducation,
+                DocScanConstants.FlowCompletion
+            };
+
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .WithSuppressedScreens(screens)
+                .Build();
+
+            Assert.AreEqual(2, sdkConfig.SuppressedScreens.Count);
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, DocScanConstants.IdDocumentEducation);
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, DocScanConstants.FlowCompletion);
+        }
+
+        [TestMethod]
+        public void WithSuppressedScreensShouldFilterUnknownValues()
+        {
+            List<string> screens = new List<string>
+            {
+                DocScanConstants.IdDocumentEducation,
+                "UNKNOWN_SCREEN",
+                DocScanConstants.FlowCompletion
+            };
+
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .WithSuppressedScreens(screens)
+                .Build();
+
+            Assert.AreEqual(2, sdkConfig.SuppressedScreens.Count);
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, DocScanConstants.IdDocumentEducation);
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, DocScanConstants.FlowCompletion);
+            CollectionAssert.DoesNotContain(sdkConfig.SuppressedScreens, "UNKNOWN_SCREEN");
+        }
+
+        [TestMethod]
+        public void WithSuppressedScreensNullShouldClearPreviousValues()
+        {
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .WithSuppressedScreen(DocScanConstants.FlowCompletion)
+                .WithSuppressedScreens(null)
+                .Build();
+
+            Assert.IsNull(sdkConfig.SuppressedScreens);
+        }
+
+        [TestMethod]
+        public void WithSuppressedScreensShouldReplacePreviousValues()
+        {
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .WithSuppressedScreen(DocScanConstants.IdDocumentEducation)
+                .WithSuppressedScreens(new List<string> { DocScanConstants.FlowCompletion })
+                .Build();
+
+            Assert.AreEqual(1, sdkConfig.SuppressedScreens.Count);
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, DocScanConstants.FlowCompletion);
+            CollectionAssert.DoesNotContain(sdkConfig.SuppressedScreens, DocScanConstants.IdDocumentEducation);
+        }
+
+        [TestMethod]
+        public void SuppressedScreensShouldSerializeWithCorrectJsonKey()
+        {
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .WithSuppressedScreen(DocScanConstants.FlowCompletion)
+                .Build();
+
+            string json = JsonConvert.SerializeObject(sdkConfig);
+            JObject parsed = JObject.Parse(json);
+
+            Assert.IsTrue(parsed.ContainsKey("suppressed_screens"));
+            JArray array = (JArray)parsed["suppressed_screens"];
+            Assert.AreEqual(1, array.Count);
+            Assert.AreEqual("FLOW_COMPLETION", array[0].ToString());
+        }
+
+        [TestMethod]
+        public void SuppressedScreensShouldDeserializeFromJson()
+        {
+            string json = @"{
+                ""suppressed_screens"": [""ID_DOCUMENT_EDUCATION"", ""FLOW_COMPLETION""]
+            }";
+
+            SdkConfig sdkConfig = JsonConvert.DeserializeObject<SdkConfig>(json);
+
+            Assert.IsNotNull(sdkConfig.SuppressedScreens);
+            Assert.AreEqual(2, sdkConfig.SuppressedScreens.Count);
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, "ID_DOCUMENT_EDUCATION");
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, "FLOW_COMPLETION");
+        }
+
+        [TestMethod]
+        public void SuppressedScreensShouldDeserializeAsNullWhenAbsent()
+        {
+            string json = @"{}";
+
+            SdkConfig sdkConfig = JsonConvert.DeserializeObject<SdkConfig>(json);
+
+            Assert.IsNull(sdkConfig.SuppressedScreens);
+        }
+
+        [TestMethod]
+        public void SuppressedScreensShouldDeserializeAsNullWhenJsonValueIsNull()
+        {
+            string json = @"{ ""suppressed_screens"": null }";
+
+            SdkConfig sdkConfig = JsonConvert.DeserializeObject<SdkConfig>(json);
+
+            Assert.IsNull(sdkConfig.SuppressedScreens);
+        }
+
+        [TestMethod]
+        public void SuppressedScreensShouldDeserializeAsEmptyListWhenJsonArrayIsEmpty()
+        {
+            string json = @"{ ""suppressed_screens"": [] }";
+
+            SdkConfig sdkConfig = JsonConvert.DeserializeObject<SdkConfig>(json);
+
+            Assert.IsNotNull(sdkConfig.SuppressedScreens);
+            Assert.AreEqual(0, sdkConfig.SuppressedScreens.Count);
         }
     }
 }


### PR DESCRIPTION
## Summary
Adds support for the IDV shortened flow by allowing integrators to configure which IDV client screens should be suppressed (omitted) during a session. A new `suppressed_screens` field is exposed on `SdkConfig`, together with builder methods and a fixed set of valid screen identifiers defined as constants.

## Changes
- `src/Yoti.Auth/Constants/DocScanConstants.cs`: Added seven new screen identifier constants (`ID_DOCUMENT_EDUCATION`, `ID_DOCUMENT_REQUIREMENTS`, `SUPPLEMENTARY_DOCUMENT_EDUCATION`, `ZOOM_LIVENESS_EDUCATION`, `STATIC_LIVENESS_EDUCATION`, `FACE_CAPTURE_EDUCATION`, `FLOW_COMPLETION`).
- `src/Yoti.Auth/DocScan/Session/Create/SdkConfig.cs`: Added a `SuppressedScreens` property (serialized as `suppressed_screens` with `NullValueHandling.Ignore`) and a new optional constructor parameter.
- `src/Yoti.Auth/DocScan/Session/Create/SdkConfigBuilder.cs`: Added `WithSuppressedScreen(string)` and `WithSuppressedScreens(List<string>)` builder methods. Invalid/unknown identifiers are filtered out silently, duplicates are removed, and passing `null` to `WithSuppressedScreens` clears previously configured values.
- `test/Yoti.Auth.Tests/DocScan/Session/Create/SdkConfigBuilderTests.cs`: Added 16 unit tests covering default state, single/multiple values, filtering of unknown/null/empty identifiers, deduplication, replacement/clearing semantics, and JSON (de)serialization.

## QA Test Steps
1. **Setup**
   - Check out branch `websdk-auto/SDK-2612-dotnet-idv---support-configuration-for-idv-shortened-flow`.
   - Restore and build: `dotnet restore && dotnet build`.
2. **Run unit tests**
   - `dotnet test test/Yoti.Auth.Tests --filter "FullyQualifiedName~SdkConfigBuilderTests"`.
   - Verify all new `SuppressedScreens*` tests pass alongside existing tests (no regressions).
3. **Happy path — single screen**
   - Build an `SdkConfig` with `.WithSuppressedScreen(DocScanConstants.IdDocumentEducation).Build()`.
   - Serialize via `JsonConvert.SerializeObject` and confirm JSON contains `"suppressed_screens": ["ID_DOCUMENT_EDUCATION"]`.
4. **Happy path — all valid screens**
   - Chain `.WithSuppressedScreen(...)` for all seven constants; assert `SuppressedScreens.Count == 7`.
5. **List API**
   - Call `.WithSuppressedScreens(new List<string> { IdDocumentEducation, FlowCompletion })`; assert both appear in the built config.
6. **Edge cases**
   - Unknown identifier (e.g. `"FOO_BAR"`): confirm it is silently ignored and `SuppressedScreens` remains `null` if no other values set.
   - Null/empty string passed to `WithSuppressedScreen`: confirm it is ignored.
   - Duplicate values: add the same identifier twice; confirm only one entry exists.
   - `WithSuppressedScreens(null)` after adding values: confirm the list is cleared (`SuppressedScreens == null`).
   - `WithSuppressedScreens(new List<string>{…})` after prior single adds: confirm the list replaces previous values (not merged).
   - Mixed list with unknown values: confirm unknowns filtered, valid ones retained.
7. **Serialization regression checks**
   - Build an `SdkConfig` with no suppressed screens; confirm serialized JSON does NOT contain the `suppressed_screens` key.
   - Deserialize `{}` → `SuppressedScreens` should be `null`.
   - Deserialize `{ "suppressed_screens": null }` → `null`.
   - Deserialize `{ "suppressed_screens": [] }` → empty list.
   - Deserialize `{ "suppressed_screens": ["ID_DOCUMENT_EDUCATION","FLOW_COMPLETION"] }` → list of two values preserved.
8. **End-to-end (optional, if IDV backend available)**
   - Create a DocScan session with a `SessionSpec` containing the new `SdkConfig` with one or more suppressed screens; confirm the request payload sent to the IDV API includes `suppressed_screens` and that the resulting IDV web client flow skips the suppressed screen(s).
9. **Regression**
   - Re-run existing `SdkConfigBuilderTests` (capture methods, colours, URLs, attempts configuration) to confirm none are affected by the new constructor parameter.

## Notes
- Invalid/unknown screen identifiers are silently filtered rather than raising an exception. This is intentional so the SDK remains forward-compatible if new screen IDs are introduced server-side before the SDK is updated — see the XML doc on `WithSuppressedScreen`.
- The `suppressed_screens` JSON field uses `NullValueHandling.Ignore`, so it is only emitted when at least one screen has been configured; this avoids changing the request payload for existing integrators.
- `WithSuppressedScreens(List<string>)` *replaces* any previously configured values rather than merging, matching the typical builder "setter" pattern. Passing `null` clears the list entirely.
- Valid screen identifiers are stored in a private `HashSet<string>` within the builder; keep this set in sync with `DocScanConstants` if additional screens are added in the future.

---

*Related Jira:* SDK-2612
*Auto-generated by n8n + Claude CLI*