### PR TITLE
SDK-2612: IDV - Support configuration for IDV shortened flow - dotnet

### DIFF
--- a/src/Yoti.Auth/Constants/DocScanConstants.cs
+++ b/src/Yoti.Auth/Constants/DocScanConstants.cs
@@ -74,5 +74,13 @@
         public const string Generic = "GENERIC";
 
         public const string VerifyShareCodeTask = "VERIFY_SHARE_CODE_TASK";
+
+        public const string IdDocumentEducation = "ID_DOCUMENT_EDUCATION";
+        public const string IdDocumentRequirements = "ID_DOCUMENT_REQUIREMENTS";
+        public const string SupplementaryDocumentEducation = "SUPPLEMENTARY_DOCUMENT_EDUCATION";
+        public const string ZoomLivenessEducation = "ZOOM_LIVENESS_EDUCATION";
+        public const string StaticLivenessEducation = "STATIC_LIVENESS_EDUCATION";
+        public const string FaceCaptureEducation = "FACE_CAPTURE_EDUCATION";
+        public const string FlowCompletion = "FLOW_COMPLETION";
     }
 }

--- a/src/Yoti.Auth/DocScan/Session/Create/SdkConfig.cs
+++ b/src/Yoti.Auth/DocScan/Session/Create/SdkConfig.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using System.Collections.Generic;
 
 namespace Yoti.Auth.DocScan.Session.Create
@@ -41,6 +41,9 @@ namespace Yoti.Auth.DocScan.Session.Create
         [JsonProperty(PropertyName = "attempts_configuration")]
         public AttemptsConfiguration AttemptsConfiguration { get; }
 
+        [JsonProperty(PropertyName = "suppressed_screens", NullValueHandling = NullValueHandling.Ignore)]
+        public List<string> SuppressedScreens { get; }
+
         public SdkConfig(string allowedCaptureMethods,
                             string primaryColour,
                             string secondaryColour,
@@ -51,7 +54,8 @@ namespace Yoti.Auth.DocScan.Session.Create
                             string errorUrl,
                             string privacyPolicyUrl,
                             bool? allowHandoff = null,
-                            Dictionary<string, int> idDocumentTextDataExtractionRetriesConfig = null)
+                            Dictionary<string, int> idDocumentTextDataExtractionRetriesConfig = null,
+                            List<string> suppressedScreens = null)
         {
             AllowedCaptureMethods = allowedCaptureMethods;
             PrimaryColour = primaryColour;
@@ -63,6 +67,7 @@ namespace Yoti.Auth.DocScan.Session.Create
             ErrorUrl = errorUrl;
             PrivacyPolicyUrl = privacyPolicyUrl;
             AllowHandoff = allowHandoff;
+            SuppressedScreens = suppressedScreens;
 
             if (idDocumentTextDataExtractionRetriesConfig != null)
             {

--- a/src/Yoti.Auth/DocScan/Session/Create/SdkConfigBuilder.cs
+++ b/src/Yoti.Auth/DocScan/Session/Create/SdkConfigBuilder.cs
@@ -16,6 +16,7 @@ namespace Yoti.Auth.DocScan.Session.Create
         private string _privacyPolicyUrl;
         private bool? _allowHandoff;
         private Dictionary<string, int> _idDocumentTextDataExtractionAttemptsConfig;
+        private List<string> _suppressedScreens;
 
         /// <summary>
         /// Sets the allowed capture method to "CAMERA"
@@ -234,7 +235,26 @@ namespace Yoti.Auth.DocScan.Session.Create
         {
             WithIdDocumentTextExtractionCategoryAttempts(DocScanConstants.Generic, genericAttempts);
             return this;
-        }   
+        }
+
+        /// <summary>
+        /// Sets the list of screens to suppress from the IDV flow
+        /// </summary>
+        /// <remarks>
+        ///     <para>
+        ///         Valid values are defined as constants on <see cref="DocScanConstants"/>:
+        ///         <c>ID_DOCUMENT_EDUCATION</c>, <c>ID_DOCUMENT_REQUIREMENTS</c>,
+        ///         <c>SUPPLEMENTARY_DOCUMENT_EDUCATION</c>, <c>ZOOM_LIVENESS_EDUCATION</c>,
+        ///         <c>STATIC_LIVENESS_EDUCATION</c>, <c>FACE_CAPTURE_EDUCATION</c>, <c>FLOW_COMPLETION</c>.
+        ///     </para>
+        /// </remarks>
+        /// <param name="suppressedScreens">The list of screens to suppress</param>
+        /// <returns>The <see cref="SdkConfigBuilder"/></returns>
+        public SdkConfigBuilder WithSuppressedScreens(List<string> suppressedScreens)
+        {
+            _suppressedScreens = suppressedScreens;
+            return this;
+        }
 
         /// <summary>
         /// Builds the <see cref="SdkConfig"/> based on values supplied to the builder
@@ -253,7 +273,8 @@ namespace Yoti.Auth.DocScan.Session.Create
                 _errorUrl,
                 _privacyPolicyUrl,
                 _allowHandoff,
-                _idDocumentTextDataExtractionAttemptsConfig);
+                _idDocumentTextDataExtractionAttemptsConfig,
+                _suppressedScreens);
         }
     }
 }

--- a/test/Yoti.Auth.Tests/DocScan/Session/Create/SdkConfigBuilderTests.cs
+++ b/test/Yoti.Auth.Tests/DocScan/Session/Create/SdkConfigBuilderTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
 using System.Collections.Generic;
 using Yoti.Auth.Constants;
 using Yoti.Auth.DocScan.Session.Create;
@@ -230,6 +231,124 @@ namespace Yoti.Auth.Tests.DocScan.Session.Create
             CollectionAssert.Contains(sdkConfig.AttemptsConfiguration.IdDocumentTextDataExtraction, kvpReclassificationAttempts);
             CollectionAssert.Contains(sdkConfig.AttemptsConfiguration.IdDocumentTextDataExtraction, kvpUsersChoiceOfCategory);
             CollectionAssert.Contains(sdkConfig.AttemptsConfiguration.IdDocumentTextDataExtraction, kvpGenericAttempts);
+        }
+
+        [TestMethod]
+        public void ShouldBuildWithSuppressedScreens()
+        {
+            var suppressedScreens = new List<string>
+            {
+                DocScanConstants.IdDocumentEducation,
+                DocScanConstants.ZoomLivenessEducation,
+                DocScanConstants.FlowCompletion
+            };
+
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .WithSuppressedScreens(suppressedScreens)
+                .Build();
+
+            CollectionAssert.AreEqual(suppressedScreens, sdkConfig.SuppressedScreens);
+        }
+
+        [TestMethod]
+        public void SuppressedScreensShouldBeNullIfNotSet()
+        {
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .Build();
+
+            Assert.IsNull(sdkConfig.SuppressedScreens);
+        }
+
+        [TestMethod]
+        public void SuppressedScreenConstantsShouldMatchExpectedValues()
+        {
+            Assert.AreEqual("ID_DOCUMENT_EDUCATION", DocScanConstants.IdDocumentEducation);
+            Assert.AreEqual("ID_DOCUMENT_REQUIREMENTS", DocScanConstants.IdDocumentRequirements);
+            Assert.AreEqual("SUPPLEMENTARY_DOCUMENT_EDUCATION", DocScanConstants.SupplementaryDocumentEducation);
+            Assert.AreEqual("ZOOM_LIVENESS_EDUCATION", DocScanConstants.ZoomLivenessEducation);
+            Assert.AreEqual("STATIC_LIVENESS_EDUCATION", DocScanConstants.StaticLivenessEducation);
+            Assert.AreEqual("FACE_CAPTURE_EDUCATION", DocScanConstants.FaceCaptureEducation);
+            Assert.AreEqual("FLOW_COMPLETION", DocScanConstants.FlowCompletion);
+        }
+
+        [TestMethod]
+        public void SerializedSdkConfigShouldIncludeSuppressedScreensWhenSet()
+        {
+            var suppressedScreens = new List<string>
+            {
+                DocScanConstants.IdDocumentEducation,
+                DocScanConstants.FlowCompletion
+            };
+
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .WithSuppressedScreens(suppressedScreens)
+                .Build();
+
+            string json = JsonConvert.SerializeObject(sdkConfig);
+
+            StringAssert.Contains(json, "\"suppressed_screens\":[\"ID_DOCUMENT_EDUCATION\",\"FLOW_COMPLETION\"]");
+        }
+
+        [TestMethod]
+        public void SerializedSdkConfigShouldOmitSuppressedScreensWhenNotSet()
+        {
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .Build();
+
+            string json = JsonConvert.SerializeObject(sdkConfig);
+
+            Assert.IsFalse(json.Contains("suppressed_screens"));
+        }
+
+        [TestMethod]
+        public void DeserializedSdkConfigShouldParseSuppressedScreens()
+        {
+            string json = "{\"suppressed_screens\":[\"ID_DOCUMENT_EDUCATION\",\"FLOW_COMPLETION\"]}";
+
+            SdkConfig sdkConfig = JsonConvert.DeserializeObject<SdkConfig>(json);
+
+            Assert.IsNotNull(sdkConfig.SuppressedScreens);
+            Assert.AreEqual(2, sdkConfig.SuppressedScreens.Count);
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, DocScanConstants.IdDocumentEducation);
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, DocScanConstants.FlowCompletion);
+        }
+
+        [TestMethod]
+        public void DeserializedSdkConfigShouldHandleMissingSuppressedScreens()
+        {
+            string json = "{}";
+
+            SdkConfig sdkConfig = JsonConvert.DeserializeObject<SdkConfig>(json);
+
+            Assert.IsNull(sdkConfig.SuppressedScreens);
+        }
+
+        [TestMethod]
+        public void DeserializedSdkConfigShouldHandleEmptySuppressedScreensArray()
+        {
+            string json = "{\"suppressed_screens\":[]}";
+
+            SdkConfig sdkConfig = JsonConvert.DeserializeObject<SdkConfig>(json);
+
+            Assert.IsNotNull(sdkConfig.SuppressedScreens);
+            Assert.AreEqual(0, sdkConfig.SuppressedScreens.Count);
+        }
+
+        [TestMethod]
+        public void DeserializedSdkConfigShouldHandleUnknownSuppressedScreenValue()
+        {
+            string json = "{\"suppressed_screens\":[\"ID_DOCUMENT_EDUCATION\",\"SOME_FUTURE_SCREEN\"]}";
+
+            SdkConfig sdkConfig = JsonConvert.DeserializeObject<SdkConfig>(json);
+
+            Assert.IsNotNull(sdkConfig.SuppressedScreens);
+            Assert.AreEqual(2, sdkConfig.SuppressedScreens.Count);
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, DocScanConstants.IdDocumentEducation);
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, "SOME_FUTURE_SCREEN");
         }
     }
 }


### PR DESCRIPTION
## Summary
Adds support for configuring the IDV shortened flow by allowing clients to suppress specific screens in the document scan session SDK configuration. This introduces a new `WithSuppressedScreens` builder method on `SdkConfigBuilder` that accepts a list of screen identifiers, which are serialized as `suppressed_screens` in the session creation payload and omitted when not set.

## Changes
- `src/Yoti.Auth/Constants/DocScanConstants.cs`: Added seven new screen identifier constants (`ID_DOCUMENT_EDUCATION`, `ID_DOCUMENT_REQUIREMENTS`, `SUPPLEMENTARY_DOCUMENT_EDUCATION`, `ZOOM_LIVENESS_EDUCATION`, `STATIC_LIVENESS_EDUCATION`, `FACE_CAPTURE_EDUCATION`, `FLOW_COMPLETION`).
- `src/Yoti.Auth/DocScan/Session/Create/SdkConfig.cs`: Added `SuppressedScreens` property serialized as `suppressed_screens` with `NullValueHandling.Ignore`; extended constructor with an optional `suppressedScreens` parameter.
- `src/Yoti.Auth/DocScan/Session/Create/SdkConfigBuilder.cs`: Added private `_suppressedScreens` field and public `WithSuppressedScreens(List<string>)` method; wired it into `Build()`.
- `test/Yoti.Auth.Tests/DocScan/Session/Create/SdkConfigBuilderTests.cs`: Added 9 tests covering builder behavior, constant values, serialization (present/omitted), and deserialization (present/missing/empty/unknown values).

## QA Test Steps
1. **Setup**: Check out the branch and run `dotnet restore` and `dotnet build` for the solution.
2. **Run unit tests**: Execute `dotnet test test/Yoti.Auth.Tests/Yoti.Auth.Tests.csproj --filter "FullyQualifiedName~SdkConfigBuilderTests"` and confirm all tests pass — pay particular attention to the nine new tests:
   - `ShouldBuildWithSuppressedScreens`
   - `SuppressedScreensShouldBeNullIfNotSet`
   - `SuppressedScreenConstantsShouldMatchExpectedValues`
   - `SerializedSdkConfigShouldIncludeSuppressedScreensWhenSet`
   - `SerializedSdkConfigShouldOmitSuppressedScreensWhenNotSet`
   - `DeserializedSdkConfigShouldParseSuppressedScreens`
   - `DeserializedSdkConfigShouldHandleMissingSuppressedScreens`
   - `DeserializedSdkConfigShouldHandleEmptySuppressedScreensArray`
   - `DeserializedSdkConfigShouldHandleUnknownSuppressedScreenValue`
3. **Happy path — builder integration**: In a sample app, build an `SdkConfig` via `new SdkConfigBuilder().WithSuppressedScreens(new List<string> { DocScanConstants.IdDocumentEducation, DocScanConstants.FlowCompletion }).Build();` and assert `SuppressedScreens` contains both values in order.
4. **Happy path — JSON payload**: Serialize the above `SdkConfig` with `JsonConvert.SerializeObject(...)` and confirm the output contains `"suppressed_screens":["ID_DOCUMENT_EDUCATION","FLOW_COMPLETION"]`.
5. **Omission behavior**: Build an `SdkConfig` without calling `WithSuppressedScreens`, serialize it, and confirm the JSON does **not** contain the `suppressed_screens` key (validates `NullValueHandling.Ignore`).
6. **Empty list**: Call `.WithSuppressedScreens(new List<string>())` and confirm it serializes as `"suppressed_screens":[]` (not omitted).
7. **End-to-end regression**: Create a DocScan session against a test tenant using an `SdkConfig` built with suppressed screens and confirm the backend accepts the payload and (if supported in the test environment) the IDV web flow skips the suppressed screens.
8. **Backwards-compatibility regression**: Re-run any existing DocScan session-creation smoke tests that do not use `WithSuppressedScreens` to confirm existing consumers are unaffected.
9. **Deserialization regression**: Deserialize a session config response containing `suppressed_screens` and confirm the list is populated on the resulting `SdkConfig` object.

## Notes
- Screen identifiers are modeled as `List<string>` plus string constants rather than a strongly-typed enum, matching the existing pattern used elsewhere in `DocScanConstants` (e.g., `Generic`, `VerifyShareCodeTask`). This keeps the SDK forward-compatible if the backend adds new screen types before the SDK is updated — validated by the `DeserializedSdkConfigShouldHandleUnknownSuppressedScreenValue` test.
- No validation is performed on the contents of the list; the caller is trusted to pass valid values (documented in the XML docs on `WithSuppressedScreens`).
- `NullValueHandling.Ignore` is applied so that existing session-creation payloads remain byte-identical when the new field is not used — important for consumers who diff or snapshot request bodies.
- The diff also normalizes BOMs/trailing newlines in `SdkConfig.cs` and `SdkConfigBuilder.cs`; these are cosmetic and non-functional.

---

*Related Jira:* SDK-2612
*Auto-generated by n8n + Claude CLI*