### PR TITLE
SDK-2612: IDV - Support configuration for IDV shortened flow - dotnet

### DIFF
--- a/src/Yoti.Auth/Constants/DocScanConstants.cs
+++ b/src/Yoti.Auth/Constants/DocScanConstants.cs
@@ -74,5 +74,13 @@
         public const string Generic = "GENERIC";
 
         public const string VerifyShareCodeTask = "VERIFY_SHARE_CODE_TASK";
+
+        public const string SuppressedScreenIdDocumentEducation = "ID_DOCUMENT_EDUCATION";
+        public const string SuppressedScreenIdDocumentRequirements = "ID_DOCUMENT_REQUIREMENTS";
+        public const string SuppressedScreenSupplementaryDocumentEducation = "SUPPLEMENTARY_DOCUMENT_EDUCATION";
+        public const string SuppressedScreenZoomLivenessEducation = "ZOOM_LIVENESS_EDUCATION";
+        public const string SuppressedScreenStaticLivenessEducation = "STATIC_LIVENESS_EDUCATION";
+        public const string SuppressedScreenFaceCaptureEducation = "FACE_CAPTURE_EDUCATION";
+        public const string SuppressedScreenFlowCompletion = "FLOW_COMPLETION";
     }
 }

--- a/src/Yoti.Auth/DocScan/Session/Create/SdkConfig.cs
+++ b/src/Yoti.Auth/DocScan/Session/Create/SdkConfig.cs
@@ -41,6 +41,9 @@ namespace Yoti.Auth.DocScan.Session.Create
         [JsonProperty(PropertyName = "attempts_configuration")]
         public AttemptsConfiguration AttemptsConfiguration { get; }
 
+        [JsonProperty(PropertyName = "suppressed_screens")]
+        public List<string> SuppressedScreens { get; }
+
         public SdkConfig(string allowedCaptureMethods,
                             string primaryColour,
                             string secondaryColour,
@@ -51,7 +54,8 @@ namespace Yoti.Auth.DocScan.Session.Create
                             string errorUrl,
                             string privacyPolicyUrl,
                             bool? allowHandoff = null,
-                            Dictionary<string, int> idDocumentTextDataExtractionRetriesConfig = null)
+                            Dictionary<string, int> idDocumentTextDataExtractionRetriesConfig = null,
+                            List<string> suppressedScreens = null)
         {
             AllowedCaptureMethods = allowedCaptureMethods;
             PrimaryColour = primaryColour;
@@ -63,6 +67,7 @@ namespace Yoti.Auth.DocScan.Session.Create
             ErrorUrl = errorUrl;
             PrivacyPolicyUrl = privacyPolicyUrl;
             AllowHandoff = allowHandoff;
+            SuppressedScreens = suppressedScreens;
 
             if (idDocumentTextDataExtractionRetriesConfig != null)
             {

--- a/src/Yoti.Auth/DocScan/Session/Create/SdkConfigBuilder.cs
+++ b/src/Yoti.Auth/DocScan/Session/Create/SdkConfigBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Yoti.Auth.Constants;
 
 namespace Yoti.Auth.DocScan.Session.Create
@@ -16,6 +17,7 @@ namespace Yoti.Auth.DocScan.Session.Create
         private string _privacyPolicyUrl;
         private bool? _allowHandoff;
         private Dictionary<string, int> _idDocumentTextDataExtractionAttemptsConfig;
+        private List<string> _suppressedScreens;
 
         /// <summary>
         /// Sets the allowed capture method to "CAMERA"
@@ -234,7 +236,36 @@ namespace Yoti.Auth.DocScan.Session.Create
         {
             WithIdDocumentTextExtractionCategoryAttempts(DocScanConstants.Generic, genericAttempts);
             return this;
-        }   
+        }
+
+        private static readonly IReadOnlyList<string> AllowedSuppressedScreens = new List<string>
+        {
+            DocScanConstants.SuppressedScreenIdDocumentEducation,
+            DocScanConstants.SuppressedScreenIdDocumentRequirements,
+            DocScanConstants.SuppressedScreenSupplementaryDocumentEducation,
+            DocScanConstants.SuppressedScreenZoomLivenessEducation,
+            DocScanConstants.SuppressedScreenStaticLivenessEducation,
+            DocScanConstants.SuppressedScreenFaceCaptureEducation,
+            DocScanConstants.SuppressedScreenFlowCompletion,
+        };
+
+        /// <summary>
+        /// Sets the list of screens to suppress in the IDV flow
+        /// </summary>
+        /// <param name="screens">Screen identifiers to suppress</param>
+        /// <returns>The <see cref="SdkConfigBuilder"/></returns>
+        /// <exception cref="System.ArgumentException">Thrown if any screen identifier is not a recognised value</exception>
+        public SdkConfigBuilder WithSuppressedScreens(IEnumerable<string> screens)
+        {
+            var screenList = screens?.ToList() ?? new List<string>();
+            var unknown = screenList.Except(AllowedSuppressedScreens).ToList();
+            if (unknown.Count > 0)
+                throw new System.ArgumentException(
+                    $"Unknown suppressed screen identifier(s): {string.Join(", ", unknown)}");
+
+            _suppressedScreens = screenList;
+            return this;
+        }
 
         /// <summary>
         /// Builds the <see cref="SdkConfig"/> based on values supplied to the builder
@@ -253,7 +284,8 @@ namespace Yoti.Auth.DocScan.Session.Create
                 _errorUrl,
                 _privacyPolicyUrl,
                 _allowHandoff,
-                _idDocumentTextDataExtractionAttemptsConfig);
+                _idDocumentTextDataExtractionAttemptsConfig,
+                _suppressedScreens);
         }
     }
 }

--- a/test/Yoti.Auth.Tests/DocScan/Session/Create/SdkConfigBuilderTests.cs
+++ b/test/Yoti.Auth.Tests/DocScan/Session/Create/SdkConfigBuilderTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.Collections.Generic;
 using Yoti.Auth.Constants;
 using Yoti.Auth.DocScan.Session.Create;
@@ -230,6 +231,85 @@ namespace Yoti.Auth.Tests.DocScan.Session.Create
             CollectionAssert.Contains(sdkConfig.AttemptsConfiguration.IdDocumentTextDataExtraction, kvpReclassificationAttempts);
             CollectionAssert.Contains(sdkConfig.AttemptsConfiguration.IdDocumentTextDataExtraction, kvpUsersChoiceOfCategory);
             CollectionAssert.Contains(sdkConfig.AttemptsConfiguration.IdDocumentTextDataExtraction, kvpGenericAttempts);
+        }
+
+        [TestMethod]
+        public void SuppressedScreensShouldBeNullIfNotSet()
+        {
+            SdkConfig sdkConfig = new SdkConfigBuilder().Build();
+
+            Assert.IsNull(sdkConfig.SuppressedScreens);
+        }
+
+        [TestMethod]
+        public void ShouldBuildWithSuppressedScreens()
+        {
+            var screens = new List<string>
+            {
+                DocScanConstants.SuppressedScreenIdDocumentEducation,
+                DocScanConstants.SuppressedScreenFlowCompletion,
+            };
+
+            SdkConfig sdkConfig = new SdkConfigBuilder()
+                .WithSuppressedScreens(screens)
+                .Build();
+
+            CollectionAssert.AreEquivalent(screens, sdkConfig.SuppressedScreens);
+        }
+
+        [TestMethod]
+        public void ShouldBuildWithEmptySuppressedScreens()
+        {
+            SdkConfig sdkConfig = new SdkConfigBuilder()
+                .WithSuppressedScreens(new List<string>())
+                .Build();
+
+            Assert.IsNotNull(sdkConfig.SuppressedScreens);
+            Assert.AreEqual(0, sdkConfig.SuppressedScreens.Count);
+        }
+
+        [TestMethod]
+        public void ShouldBuildWithAllSuppressedScreens()
+        {
+            var allScreens = new List<string>
+            {
+                DocScanConstants.SuppressedScreenIdDocumentEducation,
+                DocScanConstants.SuppressedScreenIdDocumentRequirements,
+                DocScanConstants.SuppressedScreenSupplementaryDocumentEducation,
+                DocScanConstants.SuppressedScreenZoomLivenessEducation,
+                DocScanConstants.SuppressedScreenStaticLivenessEducation,
+                DocScanConstants.SuppressedScreenFaceCaptureEducation,
+                DocScanConstants.SuppressedScreenFlowCompletion,
+            };
+
+            SdkConfig sdkConfig = new SdkConfigBuilder()
+                .WithSuppressedScreens(allScreens)
+                .Build();
+
+            CollectionAssert.AreEquivalent(allScreens, sdkConfig.SuppressedScreens);
+        }
+
+        [TestMethod]
+        public void ShouldThrowForUnknownSuppressedScreen()
+        {
+            Assert.ThrowsException<ArgumentException>(() =>
+                new SdkConfigBuilder()
+                    .WithSuppressedScreens(new List<string> { "UNKNOWN_SCREEN" })
+                    .Build());
+        }
+
+        [TestMethod]
+        public void SuppressedScreensShouldOverridePreviousCallToWithSuppressedScreens()
+        {
+            var first = new List<string> { DocScanConstants.SuppressedScreenIdDocumentEducation };
+            var second = new List<string> { DocScanConstants.SuppressedScreenFlowCompletion };
+
+            SdkConfig sdkConfig = new SdkConfigBuilder()
+                .WithSuppressedScreens(first)
+                .WithSuppressedScreens(second)
+                .Build();
+
+            CollectionAssert.AreEquivalent(second, sdkConfig.SuppressedScreens);
         }
     }
 }


### PR DESCRIPTION
## Summary
This PR adds support for configuring the IDV shortened flow in the .NET SDK by introducing a `suppressed_screens` field to `SdkConfig`. Integrators can now specify which IDV UI screens to omit (e.g. education screens, flow completion screen) when creating a session, enabling a streamlined end-user journey.

## Changes
- **`DocScanConstants.cs`** — Added 7 new screen identifier constants (`SuppressedScreenIdDocumentEducation`, `SuppressedScreenIdDocumentRequirements`, `SuppressedScreenSupplementaryDocumentEducation`, `SuppressedScreenZoomLivenessEducation`, `SuppressedScreenStaticLivenessEducation`, `SuppressedScreenFaceCaptureEducation`, `SuppressedScreenFlowCompletion`) used to identify suppressible IDV screens.
- **`SdkConfig.cs`** — Added `SuppressedScreens` property (`List<string>`, JSON key `suppressed_screens`) and wired it through the constructor.
- **`SdkConfigBuilder.cs`** — Added `WithSuppressedScreens(IEnumerable<string>)` method with an allowlist validation guard; unknown screen identifiers throw `ArgumentException`. Added a static `AllowedSuppressedScreens` list that constrains valid inputs to the 7 defined constants.
- **`SdkConfigBuilderTests.cs`** — Added 6 new unit tests covering: null default, valid single/multiple/all screens, empty list, unknown screen rejection, and last-call-wins override behaviour.

## QA Test Steps

**Setup**
1. Build the solution: `dotnet build`
2. Run the test suite: `dotnet test`
3. Confirm all 6 new tests in `SdkConfigBuilderTests` pass alongside existing tests.

**Happy path — suppressing specific screens**
4. Construct an `SdkConfig` via `SdkConfigBuilder` calling `WithSuppressedScreens` with a list containing one or more of the valid constants (e.g. `DocScanConstants.SuppressedScreenFlowCompletion`, `DocScanConstants.SuppressedScreenIdDocumentEducation`).
5. Serialize the resulting `SdkConfig` to JSON (e.g. embed it in a `SessionSpecification`) and confirm the payload contains `"suppressed_screens": ["FLOW_COMPLETION", "ID_DOCUMENT_EDUCATION"]`.
6. Create an IDV session using the SDK against a test/sandbox environment and verify the specified screens are absent from the user-facing flow.

**Edge cases**
7. Call `WithSuppressedScreens` twice on the same builder and confirm only the second list is present in the built config (last-call-wins, `SuppressedScreensShouldOverridePreviousCallToWithSuppressedScreens`).
8. Call `WithSuppressedScreens` with an empty list — confirm `SuppressedScreens` is a non-null empty list (not null).
9. Do not call `WithSuppressedScreens` at all — confirm `SdkConfig.SuppressedScreens` is `null` and the JSON key is omitted from the serialized payload.
10. Call `WithSuppressedScreens` with an unrecognised string (e.g. `"UNKNOWN_SCREEN"`) — confirm an `ArgumentException` is thrown before `Build()` completes.
11. Pass all 7 valid screen constants simultaneously and confirm all are reflected in `SdkConfig.SuppressedScreens`.

**Regression**
12. Build an `SdkConfig` without calling `WithSuppressedScreens` and verify all pre-existing fields (`AllowedCaptureMethods`, `AttemptsConfiguration`, `AllowHandoff`, etc.) serialise correctly and are unaffected.

## Notes
- `WithSuppressedScreens` replaces the entire list on each call rather than appending; callers should pass the complete desired set in a single call.
- Validation is strict: only the 7 constants defined in `DocScanConstants` are accepted. Any future screens must be added to both `DocScanConstants` and the `AllowedSuppressedScreens` allowlist in `SdkConfigBuilder`.
- The `suppressed_screens` JSON field is omitted (not serialised as `null` or `[]`) when not set, preserving backwards compatibility with existing session payloads.

---

*Related Jira:* SDK-2612
*Auto-generated by n8n + Claude CLI*