### PR TITLE
SDK-2616: .NET - Support configuration for IDV shortened flow - dotnet

### DIFF
--- a/src/Yoti.Auth/DocScan/Session/Create/SdkConfig.cs
+++ b/src/Yoti.Auth/DocScan/Session/Create/SdkConfig.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using System.Collections.Generic;
 
 namespace Yoti.Auth.DocScan.Session.Create
@@ -41,6 +41,9 @@ namespace Yoti.Auth.DocScan.Session.Create
         [JsonProperty(PropertyName = "attempts_configuration")]
         public AttemptsConfiguration AttemptsConfiguration { get; }
 
+        [JsonProperty(PropertyName = "suppressed_screens", NullValueHandling = NullValueHandling.Ignore)]
+        public List<string> SuppressedScreens { get; }
+
         public SdkConfig(string allowedCaptureMethods,
                             string primaryColour,
                             string secondaryColour,
@@ -51,7 +54,8 @@ namespace Yoti.Auth.DocScan.Session.Create
                             string errorUrl,
                             string privacyPolicyUrl,
                             bool? allowHandoff = null,
-                            Dictionary<string, int> idDocumentTextDataExtractionRetriesConfig = null)
+                            Dictionary<string, int> idDocumentTextDataExtractionRetriesConfig = null,
+                            List<string> suppressedScreens = null)
         {
             AllowedCaptureMethods = allowedCaptureMethods;
             PrimaryColour = primaryColour;
@@ -63,6 +67,7 @@ namespace Yoti.Auth.DocScan.Session.Create
             ErrorUrl = errorUrl;
             PrivacyPolicyUrl = privacyPolicyUrl;
             AllowHandoff = allowHandoff;
+            SuppressedScreens = suppressedScreens;
 
             if (idDocumentTextDataExtractionRetriesConfig != null)
             {

--- a/src/Yoti.Auth/DocScan/Session/Create/SdkConfigBuilder.cs
+++ b/src/Yoti.Auth/DocScan/Session/Create/SdkConfigBuilder.cs
@@ -16,6 +16,7 @@ namespace Yoti.Auth.DocScan.Session.Create
         private string _privacyPolicyUrl;
         private bool? _allowHandoff;
         private Dictionary<string, int> _idDocumentTextDataExtractionAttemptsConfig;
+        private List<string> _suppressedScreens;
 
         /// <summary>
         /// Sets the allowed capture method to "CAMERA"
@@ -237,6 +238,39 @@ namespace Yoti.Auth.DocScan.Session.Create
         }   
 
         /// <summary>
+        /// Sets the list of screens to suppress from the IDV flow
+        /// </summary>
+        /// <remarks>
+        ///     <para>
+        ///         See <see cref="SuppressedScreen"/> for the set of valid screen identifiers.
+        ///     </para>
+        ///     <para>
+        ///         Unknown values are sent through to the backend as-is; the backend is responsible for validation.
+        ///     </para>
+        /// </remarks>
+        /// <param name="suppressedScreens">The list of screen identifiers to suppress</param>
+        /// <returns>The <see cref="SdkConfigBuilder"/></returns>
+        public SdkConfigBuilder WithSuppressedScreens(List<string> suppressedScreens)
+        {
+            _suppressedScreens = suppressedScreens;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the list of screens to suppress from the IDV flow
+        /// </summary>
+        /// <remarks>
+        ///     See <see cref="SuppressedScreen"/> for the set of valid screen identifiers.
+        /// </remarks>
+        /// <param name="suppressedScreens">The screen identifiers to suppress</param>
+        /// <returns>The <see cref="SdkConfigBuilder"/></returns>
+        public SdkConfigBuilder WithSuppressedScreens(params string[] suppressedScreens)
+        {
+            _suppressedScreens = suppressedScreens == null ? null : new List<string>(suppressedScreens);
+            return this;
+        }
+
+        /// <summary>
         /// Builds the <see cref="SdkConfig"/> based on values supplied to the builder
         /// </summary>
         /// <returns>The built <see cref="SdkConfig"/></returns>
@@ -253,7 +287,8 @@ namespace Yoti.Auth.DocScan.Session.Create
                 _errorUrl,
                 _privacyPolicyUrl,
                 _allowHandoff,
-                _idDocumentTextDataExtractionAttemptsConfig);
+                _idDocumentTextDataExtractionAttemptsConfig,
+                _suppressedScreens);
         }
     }
 }

--- a/src/Yoti.Auth/DocScan/Session/Create/SuppressedScreen.cs
+++ b/src/Yoti.Auth/DocScan/Session/Create/SuppressedScreen.cs
@@ -1,0 +1,16 @@
+namespace Yoti.Auth.DocScan.Session.Create
+{
+    /// <summary>
+    /// Valid values for suppressing screens in the IDV flow via <see cref="SdkConfig"/>.
+    /// </summary>
+    public static class SuppressedScreen
+    {
+        public const string IdDocumentEducation = "ID_DOCUMENT_EDUCATION";
+        public const string IdDocumentRequirements = "ID_DOCUMENT_REQUIREMENTS";
+        public const string SupplementaryDocumentEducation = "SUPPLEMENTARY_DOCUMENT_EDUCATION";
+        public const string ZoomLivenessEducation = "ZOOM_LIVENESS_EDUCATION";
+        public const string StaticLivenessEducation = "STATIC_LIVENESS_EDUCATION";
+        public const string FaceCaptureEducation = "FACE_CAPTURE_EDUCATION";
+        public const string FlowCompletion = "FLOW_COMPLETION";
+    }
+}

--- a/test/Yoti.Auth.Tests/DocScan/Session/Create/SdkConfigBuilderTests.cs
+++ b/test/Yoti.Auth.Tests/DocScan/Session/Create/SdkConfigBuilderTests.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
 using Yoti.Auth.Constants;
 using Yoti.Auth.DocScan.Session.Create;
@@ -208,6 +210,117 @@ namespace Yoti.Auth.Tests.DocScan.Session.Create
 
             Assert.AreEqual(1, sdkConfig.AttemptsConfiguration.IdDocumentTextDataExtraction.Count);
             CollectionAssert.Contains(sdkConfig.AttemptsConfiguration.IdDocumentTextDataExtraction, kvp);
+        }
+
+        [TestMethod]
+        public void ShouldBuildWithSuppressedScreensList()
+        {
+            var screens = new List<string>
+            {
+                SuppressedScreen.IdDocumentEducation,
+                SuppressedScreen.FlowCompletion
+            };
+
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .WithSuppressedScreens(screens)
+                .Build();
+
+            CollectionAssert.AreEqual(screens, sdkConfig.SuppressedScreens);
+        }
+
+        [TestMethod]
+        public void ShouldBuildWithSuppressedScreensParams()
+        {
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .WithSuppressedScreens(
+                    SuppressedScreen.ZoomLivenessEducation,
+                    SuppressedScreen.StaticLivenessEducation,
+                    SuppressedScreen.FaceCaptureEducation)
+                .Build();
+
+            var expected = new List<string>
+            {
+                SuppressedScreen.ZoomLivenessEducation,
+                SuppressedScreen.StaticLivenessEducation,
+                SuppressedScreen.FaceCaptureEducation
+            };
+            CollectionAssert.AreEqual(expected, sdkConfig.SuppressedScreens);
+        }
+
+        [TestMethod]
+        public void SuppressedScreensShouldBeNullIfNotSet()
+        {
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .Build();
+
+            Assert.IsNull(sdkConfig.SuppressedScreens);
+        }
+
+        [TestMethod]
+        public void SuppressedScreensShouldAcceptEmptyList()
+        {
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .WithSuppressedScreens(new List<string>())
+                .Build();
+
+            Assert.IsNotNull(sdkConfig.SuppressedScreens);
+            Assert.AreEqual(0, sdkConfig.SuppressedScreens.Count);
+        }
+
+        [TestMethod]
+        public void SuppressedScreensShouldBeOmittedFromJsonWhenNull()
+        {
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .Build();
+
+            string json = JsonConvert.SerializeObject(sdkConfig);
+            JObject parsed = JObject.Parse(json);
+
+            Assert.IsFalse(parsed.ContainsKey("suppressed_screens"));
+        }
+
+        [TestMethod]
+        public void SuppressedScreensShouldSerializeAllConstantsAsExpectedStrings()
+        {
+            var screens = new List<string>
+            {
+                SuppressedScreen.IdDocumentEducation,
+                SuppressedScreen.IdDocumentRequirements,
+                SuppressedScreen.SupplementaryDocumentEducation,
+                SuppressedScreen.ZoomLivenessEducation,
+                SuppressedScreen.StaticLivenessEducation,
+                SuppressedScreen.FaceCaptureEducation,
+                SuppressedScreen.FlowCompletion
+            };
+
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .WithSuppressedScreens(screens)
+                .Build();
+
+            string json = JsonConvert.SerializeObject(sdkConfig);
+            JObject parsed = JObject.Parse(json);
+
+            Assert.IsTrue(parsed.ContainsKey("suppressed_screens"));
+            var serialised = parsed["suppressed_screens"].ToObject<List<string>>();
+            CollectionAssert.AreEqual(screens, serialised);
+        }
+
+        [TestMethod]
+        public void SuppressedScreenConstantValuesShouldMatchSpec()
+        {
+            Assert.AreEqual("ID_DOCUMENT_EDUCATION", SuppressedScreen.IdDocumentEducation);
+            Assert.AreEqual("ID_DOCUMENT_REQUIREMENTS", SuppressedScreen.IdDocumentRequirements);
+            Assert.AreEqual("SUPPLEMENTARY_DOCUMENT_EDUCATION", SuppressedScreen.SupplementaryDocumentEducation);
+            Assert.AreEqual("ZOOM_LIVENESS_EDUCATION", SuppressedScreen.ZoomLivenessEducation);
+            Assert.AreEqual("STATIC_LIVENESS_EDUCATION", SuppressedScreen.StaticLivenessEducation);
+            Assert.AreEqual("FACE_CAPTURE_EDUCATION", SuppressedScreen.FaceCaptureEducation);
+            Assert.AreEqual("FLOW_COMPLETION", SuppressedScreen.FlowCompletion);
         }
 
         [TestMethod]


### PR DESCRIPTION
## Summary
Adds support for the IDV shortened flow by exposing a new `suppressed_screens` configuration on `SdkConfig`. Integrators can now opt out of specific educational/requirement screens in the Doc Scan flow via the `SdkConfigBuilder`, with a new `SuppressedScreen` constants class providing the documented screen identifiers.

## Changes
- `src/Yoti.Auth/DocScan/Session/Create/SdkConfig.cs`: Added `SuppressedScreens` property serialized as `suppressed_screens` with `NullValueHandling.Ignore`; extended the constructor with an optional `suppressedScreens` parameter.
- `src/Yoti.Auth/DocScan/Session/Create/SdkConfigBuilder.cs`: Added two overloads of `WithSuppressedScreens` (`List<string>` and `params string[]`) and wired the value into `Build()`.
- `src/Yoti.Auth/DocScan/Session/Create/SuppressedScreen.cs` (new): Static class exposing constants for the seven supported screen identifiers (`ID_DOCUMENT_EDUCATION`, `ID_DOCUMENT_REQUIREMENTS`, `SUPPLEMENTARY_DOCUMENT_EDUCATION`, `ZOOM_LIVENESS_EDUCATION`, `STATIC_LIVENESS_EDUCATION`, `FACE_CAPTURE_EDUCATION`, `FLOW_COMPLETION`).
- `test/Yoti.Auth.Tests/DocScan/Session/Create/SdkConfigBuilderTests.cs`: Seven new tests covering list/params overloads, default null behaviour, empty list, JSON omission when null, full serialization, and constant value assertions.

## QA Test Steps
1. **Setup**
   - Check out the branch and run `dotnet restore` / `dotnet build` from the repo root.
   - Run the full unit test suite: `dotnet test`. All tests must pass, including the seven new `SuppressedScreens`/`SuppressedScreen` tests in `SdkConfigBuilderTests`.
2. **Happy path — `List<string>` overload**
   - In a consumer project, build an `SdkConfig` using `new SdkConfigBuilder().WithSuppressedScreens(new List<string> { SuppressedScreen.IdDocumentEducation, SuppressedScreen.FlowCompletion }).Build();`.
   - Serialize with `JsonConvert.SerializeObject` and verify the payload contains `"suppressed_screens":["ID_DOCUMENT_EDUCATION","FLOW_COMPLETION"]`.
3. **Happy path — `params` overload**
   - Build with `WithSuppressedScreens(SuppressedScreen.ZoomLivenessEducation, SuppressedScreen.FaceCaptureEducation)` and confirm `SdkConfig.SuppressedScreens` contains both values in order.
4. **Create Doc Scan session end-to-end**
   - Using valid sandbox credentials, create a Doc Scan session whose `SdkConfig` includes `SuppressedScreens` (e.g. `ID_DOCUMENT_EDUCATION`, `FLOW_COMPLETION`).
   - Launch the resulting session in the Web SDK and confirm the suppressed screens are skipped, while non-suppressed screens still render.
5. **Edge cases**
   - Do not call `WithSuppressedScreens`: assert `SdkConfig.SuppressedScreens` is `null` and the `suppressed_screens` key is absent from the serialized JSON (regression check for `NullValueHandling.Ignore`).
   - Call `WithSuppressedScreens(new List<string>())`: assert property is non-null, empty, and the JSON contains `"suppressed_screens":[]`.
   - Call `WithSuppressedScreens((string[])null)` via the params overload: assert the property is `null` (not an empty list) and serialization omits the field.
   - Pass an unknown string (e.g. `"NOT_A_REAL_SCREEN"`): the SDK should accept and forward it verbatim — backend validation is expected to reject it.
6. **Regression checks**
   - Rebuild an `SdkConfig` that exercises other builder methods (`WithAllowedCaptureMethods`, `WithPrimaryColour`, `WithAllowHandoff`, `WithIdDocumentTextExtractionCategoryAttempts`, etc.) alongside `WithSuppressedScreens` and verify all previously-set fields still serialize correctly.
   - Confirm existing Doc Scan sample apps compile and run without changes (the new constructor parameter is optional).

## Notes
- The `SuppressedScreens` property is backed by `List<string>` rather than an enum so that integrators can forward new backend-supported screen identifiers without waiting for an SDK release. Validation is deliberately delegated to the backend (see XML doc on `WithSuppressedScreens`).
- Serialization uses `NullValueHandling.Ignore` so existing integrations produce byte-identical payloads when the new feature is unused.
- The `params string[]` overload copies into a new `List<string>` to keep the public property type stable and avoid sharing the caller's array.
- No changes were made to other SDK wrappers or sample apps in this PR; if examples are desired, that can follow up separately.

---

*Related Jira:* SDK-2616
*Auto-generated by n8n + Claude CLI*