### PR TITLE
SDK-2616: .NET - Support configuration for IDV shortened flow - dotnet

### DIFF
--- a/src/Yoti.Auth/Constants/DocScanConstants.cs
+++ b/src/Yoti.Auth/Constants/DocScanConstants.cs
@@ -74,5 +74,13 @@
         public const string Generic = "GENERIC";
 
         public const string VerifyShareCodeTask = "VERIFY_SHARE_CODE_TASK";
+
+        public const string IdDocumentEducation = "ID_DOCUMENT_EDUCATION";
+        public const string IdDocumentRequirements = "ID_DOCUMENT_REQUIREMENTS";
+        public const string SupplementaryDocumentEducation = "SUPPLEMENTARY_DOCUMENT_EDUCATION";
+        public const string ZoomLivenessEducation = "ZOOM_LIVENESS_EDUCATION";
+        public const string StaticLivenessEducation = "STATIC_LIVENESS_EDUCATION";
+        public const string FaceCaptureEducation = "FACE_CAPTURE_EDUCATION";
+        public const string FlowCompletion = "FLOW_COMPLETION";
     }
 }

--- a/src/Yoti.Auth/DocScan/Session/Create/SdkConfig.cs
+++ b/src/Yoti.Auth/DocScan/Session/Create/SdkConfig.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using System.Collections.Generic;
 
 namespace Yoti.Auth.DocScan.Session.Create
@@ -41,6 +41,14 @@ namespace Yoti.Auth.DocScan.Session.Create
         [JsonProperty(PropertyName = "attempts_configuration")]
         public AttemptsConfiguration AttemptsConfiguration { get; }
 
+        /// <summary>
+        /// The screens to suppress from the IDV flow. Each value should be one of the
+        /// constants defined in <see cref="SuppressedScreen"/>. The field is optional —
+        /// when <c>null</c> or empty, no screens are suppressed.
+        /// </summary>
+        [JsonProperty(PropertyName = "suppressed_screens")]
+        public List<string> SuppressedScreens { get; }
+
         public SdkConfig(string allowedCaptureMethods,
                             string primaryColour,
                             string secondaryColour,
@@ -51,7 +59,8 @@ namespace Yoti.Auth.DocScan.Session.Create
                             string errorUrl,
                             string privacyPolicyUrl,
                             bool? allowHandoff = null,
-                            Dictionary<string, int> idDocumentTextDataExtractionRetriesConfig = null)
+                            Dictionary<string, int> idDocumentTextDataExtractionRetriesConfig = null,
+                            List<string> suppressedScreens = null)
         {
             AllowedCaptureMethods = allowedCaptureMethods;
             PrimaryColour = primaryColour;
@@ -63,6 +72,7 @@ namespace Yoti.Auth.DocScan.Session.Create
             ErrorUrl = errorUrl;
             PrivacyPolicyUrl = privacyPolicyUrl;
             AllowHandoff = allowHandoff;
+            SuppressedScreens = suppressedScreens;
 
             if (idDocumentTextDataExtractionRetriesConfig != null)
             {

--- a/src/Yoti.Auth/DocScan/Session/Create/SdkConfigBuilder.cs
+++ b/src/Yoti.Auth/DocScan/Session/Create/SdkConfigBuilder.cs
@@ -16,6 +16,7 @@ namespace Yoti.Auth.DocScan.Session.Create
         private string _privacyPolicyUrl;
         private bool? _allowHandoff;
         private Dictionary<string, int> _idDocumentTextDataExtractionAttemptsConfig;
+        private List<string> _suppressedScreens;
 
         /// <summary>
         /// Sets the allowed capture method to "CAMERA"
@@ -234,7 +235,40 @@ namespace Yoti.Auth.DocScan.Session.Create
         {
             WithIdDocumentTextExtractionCategoryAttempts(DocScanConstants.Generic, genericAttempts);
             return this;
-        }   
+        }
+
+        /// <summary>
+        /// Sets the list of screens to suppress from the IDV flow. This allows the RP
+        /// to shorten the flow by omitting specific screens.
+        /// </summary>
+        /// <remarks>
+        ///     Use the constants defined in <see cref="SuppressedScreen"/> for valid values.
+        ///     Calling this method replaces any previously configured list.
+        /// </remarks>
+        /// <param name="suppressedScreens">The list of screens to suppress</param>
+        /// <returns>The <see cref="SdkConfigBuilder"/></returns>
+        public SdkConfigBuilder WithSuppressedScreens(List<string> suppressedScreens)
+        {
+            _suppressedScreens = suppressedScreens;
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a single screen to the list of screens to suppress from the IDV flow.
+        /// </summary>
+        /// <remarks>
+        ///     Use the constants defined in <see cref="SuppressedScreen"/> for valid values.
+        /// </remarks>
+        /// <param name="suppressedScreen">The screen to suppress</param>
+        /// <returns>The <see cref="SdkConfigBuilder"/></returns>
+        public SdkConfigBuilder WithSuppressedScreen(string suppressedScreen)
+        {
+            if (_suppressedScreens == null)
+                _suppressedScreens = new List<string>();
+
+            _suppressedScreens.Add(suppressedScreen);
+            return this;
+        }
 
         /// <summary>
         /// Builds the <see cref="SdkConfig"/> based on values supplied to the builder
@@ -253,7 +287,8 @@ namespace Yoti.Auth.DocScan.Session.Create
                 _errorUrl,
                 _privacyPolicyUrl,
                 _allowHandoff,
-                _idDocumentTextDataExtractionAttemptsConfig);
+                _idDocumentTextDataExtractionAttemptsConfig,
+                _suppressedScreens);
         }
     }
 }

--- a/src/Yoti.Auth/DocScan/Session/Create/SuppressedScreen.cs
+++ b/src/Yoti.Auth/DocScan/Session/Create/SuppressedScreen.cs
@@ -1,0 +1,17 @@
+namespace Yoti.Auth.DocScan.Session.Create
+{
+    /// <summary>
+    /// Valid values for screens that can be suppressed in the IDV flow
+    /// by passing them to <see cref="SdkConfigBuilder.WithSuppressedScreens(System.Collections.Generic.List{string})"/>
+    /// </summary>
+    public static class SuppressedScreen
+    {
+        public const string IdDocumentEducation = "ID_DOCUMENT_EDUCATION";
+        public const string IdDocumentRequirements = "ID_DOCUMENT_REQUIREMENTS";
+        public const string SupplementaryDocumentEducation = "SUPPLEMENTARY_DOCUMENT_EDUCATION";
+        public const string ZoomLivenessEducation = "ZOOM_LIVENESS_EDUCATION";
+        public const string StaticLivenessEducation = "STATIC_LIVENESS_EDUCATION";
+        public const string FaceCaptureEducation = "FACE_CAPTURE_EDUCATION";
+        public const string FlowCompletion = "FLOW_COMPLETION";
+    }
+}

--- a/test/Yoti.Auth.Tests/DocScan/Session/Create/SdkConfigBuilderTests.cs
+++ b/test/Yoti.Auth.Tests/DocScan/Session/Create/SdkConfigBuilderTests.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
 using Yoti.Auth.Constants;
 using Yoti.Auth.DocScan.Session.Create;
@@ -208,6 +210,189 @@ namespace Yoti.Auth.Tests.DocScan.Session.Create
 
             Assert.AreEqual(1, sdkConfig.AttemptsConfiguration.IdDocumentTextDataExtraction.Count);
             CollectionAssert.Contains(sdkConfig.AttemptsConfiguration.IdDocumentTextDataExtraction, kvp);
+        }
+
+        [TestMethod]
+        public void SuppressedScreensShouldBeNullIfNotSet()
+        {
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .Build();
+
+            Assert.IsNull(sdkConfig.SuppressedScreens);
+        }
+
+        [TestMethod]
+        public void ShouldBuildWithSuppressedScreens()
+        {
+            var screens = new List<string>
+            {
+                SuppressedScreen.IdDocumentEducation,
+                SuppressedScreen.FlowCompletion
+            };
+
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .WithSuppressedScreens(screens)
+                .Build();
+
+            CollectionAssert.AreEqual(screens, sdkConfig.SuppressedScreens);
+        }
+
+        [TestMethod]
+        public void ShouldBuildWithAllKnownSuppressedScreens()
+        {
+            var screens = new List<string>
+            {
+                SuppressedScreen.IdDocumentEducation,
+                SuppressedScreen.IdDocumentRequirements,
+                SuppressedScreen.SupplementaryDocumentEducation,
+                SuppressedScreen.ZoomLivenessEducation,
+                SuppressedScreen.StaticLivenessEducation,
+                SuppressedScreen.FaceCaptureEducation,
+                SuppressedScreen.FlowCompletion
+            };
+
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .WithSuppressedScreens(screens)
+                .Build();
+
+            Assert.AreEqual(7, sdkConfig.SuppressedScreens.Count);
+            Assert.AreEqual("ID_DOCUMENT_EDUCATION", sdkConfig.SuppressedScreens[0]);
+            Assert.AreEqual("ID_DOCUMENT_REQUIREMENTS", sdkConfig.SuppressedScreens[1]);
+            Assert.AreEqual("SUPPLEMENTARY_DOCUMENT_EDUCATION", sdkConfig.SuppressedScreens[2]);
+            Assert.AreEqual("ZOOM_LIVENESS_EDUCATION", sdkConfig.SuppressedScreens[3]);
+            Assert.AreEqual("STATIC_LIVENESS_EDUCATION", sdkConfig.SuppressedScreens[4]);
+            Assert.AreEqual("FACE_CAPTURE_EDUCATION", sdkConfig.SuppressedScreens[5]);
+            Assert.AreEqual("FLOW_COMPLETION", sdkConfig.SuppressedScreens[6]);
+        }
+
+        [TestMethod]
+        public void ShouldBuildWithSingleSuppressedScreen()
+        {
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .WithSuppressedScreen(SuppressedScreen.FlowCompletion)
+                .WithSuppressedScreen(SuppressedScreen.IdDocumentRequirements)
+                .Build();
+
+            Assert.AreEqual(2, sdkConfig.SuppressedScreens.Count);
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, "FLOW_COMPLETION");
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, "ID_DOCUMENT_REQUIREMENTS");
+        }
+
+        [TestMethod]
+        public void ShouldBuildWithEmptySuppressedScreensList()
+        {
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .WithSuppressedScreens(new List<string>())
+                .Build();
+
+            Assert.IsNotNull(sdkConfig.SuppressedScreens);
+            Assert.AreEqual(0, sdkConfig.SuppressedScreens.Count);
+        }
+
+        [TestMethod]
+        public void SuppressedScreensShouldSerializeToJson()
+        {
+            var screens = new List<string>
+            {
+                SuppressedScreen.IdDocumentEducation,
+                SuppressedScreen.FlowCompletion
+            };
+
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .WithSuppressedScreens(screens)
+                .Build();
+
+            string json = JsonConvert.SerializeObject(sdkConfig);
+            JObject parsed = JObject.Parse(json);
+
+            Assert.IsNotNull(parsed["suppressed_screens"]);
+            var serializedScreens = parsed["suppressed_screens"].ToObject<List<string>>();
+            CollectionAssert.AreEqual(screens, serializedScreens);
+        }
+
+        [TestMethod]
+        public void SuppressedScreensShouldNotSerializeWhenNull()
+        {
+            SdkConfig sdkConfig =
+                new SdkConfigBuilder()
+                .Build();
+
+            var settings = new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore };
+            string json = JsonConvert.SerializeObject(sdkConfig, settings);
+            JObject parsed = JObject.Parse(json);
+
+            Assert.IsNull(parsed["suppressed_screens"]);
+        }
+
+        [TestMethod]
+        public void SuppressedScreensShouldDeserializeFromJson()
+        {
+            string json = @"{
+                ""allowed_capture_methods"": ""CAMERA"",
+                ""suppressed_screens"": [""ID_DOCUMENT_EDUCATION"", ""FLOW_COMPLETION""]
+            }";
+
+            SdkConfig sdkConfig = JsonConvert.DeserializeObject<SdkConfig>(json);
+
+            Assert.IsNotNull(sdkConfig.SuppressedScreens);
+            Assert.AreEqual(2, sdkConfig.SuppressedScreens.Count);
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, "ID_DOCUMENT_EDUCATION");
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, "FLOW_COMPLETION");
+        }
+
+        [TestMethod]
+        public void SuppressedScreensShouldDeserializeWhenAbsent()
+        {
+            string json = @"{ ""allowed_capture_methods"": ""CAMERA"" }";
+
+            SdkConfig sdkConfig = JsonConvert.DeserializeObject<SdkConfig>(json);
+
+            Assert.IsNull(sdkConfig.SuppressedScreens);
+        }
+
+        [TestMethod]
+        public void SuppressedScreensShouldDeserializeEmptyArray()
+        {
+            string json = @"{ ""suppressed_screens"": [] }";
+
+            SdkConfig sdkConfig = JsonConvert.DeserializeObject<SdkConfig>(json);
+
+            Assert.IsNotNull(sdkConfig.SuppressedScreens);
+            Assert.AreEqual(0, sdkConfig.SuppressedScreens.Count);
+        }
+
+        [TestMethod]
+        public void SuppressedScreensShouldDeserializeUnknownValuesGracefully()
+        {
+            string json = @"{
+                ""suppressed_screens"": [""ID_DOCUMENT_EDUCATION"", ""SOME_FUTURE_SCREEN"", ""FLOW_COMPLETION""]
+            }";
+
+            SdkConfig sdkConfig = JsonConvert.DeserializeObject<SdkConfig>(json);
+
+            Assert.IsNotNull(sdkConfig.SuppressedScreens);
+            Assert.AreEqual(3, sdkConfig.SuppressedScreens.Count);
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, "ID_DOCUMENT_EDUCATION");
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, "SOME_FUTURE_SCREEN");
+            CollectionAssert.Contains(sdkConfig.SuppressedScreens, "FLOW_COMPLETION");
+        }
+
+        [TestMethod]
+        public void SuppressedScreenConstantsShouldMatchExpectedValues()
+        {
+            Assert.AreEqual("ID_DOCUMENT_EDUCATION", SuppressedScreen.IdDocumentEducation);
+            Assert.AreEqual("ID_DOCUMENT_REQUIREMENTS", SuppressedScreen.IdDocumentRequirements);
+            Assert.AreEqual("SUPPLEMENTARY_DOCUMENT_EDUCATION", SuppressedScreen.SupplementaryDocumentEducation);
+            Assert.AreEqual("ZOOM_LIVENESS_EDUCATION", SuppressedScreen.ZoomLivenessEducation);
+            Assert.AreEqual("STATIC_LIVENESS_EDUCATION", SuppressedScreen.StaticLivenessEducation);
+            Assert.AreEqual("FACE_CAPTURE_EDUCATION", SuppressedScreen.FaceCaptureEducation);
+            Assert.AreEqual("FLOW_COMPLETION", SuppressedScreen.FlowCompletion);
         }
 
         [TestMethod]

--- a/test/Yoti.Auth.Tests/DocScan/Session/Create/SessionSpecificationBuilderTests.cs
+++ b/test/Yoti.Auth.Tests/DocScan/Session/Create/SessionSpecificationBuilderTests.cs
@@ -102,6 +102,28 @@ namespace Yoti.Auth.Tests.DocScan.Session.Create
         }
 
         [TestMethod]
+        public void SdkConfigSuppressedScreensShouldBeSerializedInSessionSpecification()
+        {
+            SessionSpecification sessionSpec =
+              new SessionSpecificationBuilder()
+              .WithSdkConfig(
+                  new SdkConfigBuilder()
+                  .WithSuppressedScreens(new List<string>
+                  {
+                      SuppressedScreen.IdDocumentEducation,
+                      SuppressedScreen.FlowCompletion
+                  })
+                  .Build())
+              .Build();
+
+            string json = JsonConvert.SerializeObject(sessionSpec);
+
+            Assert.IsTrue(json.Contains("\"suppressed_screens\""));
+            Assert.IsTrue(json.Contains("ID_DOCUMENT_EDUCATION"));
+            Assert.IsTrue(json.Contains("FLOW_COMPLETION"));
+        }
+
+        [TestMethod]
         public void ShouldBuildWithUserTrackingId()
         {
             string userTrackingId = "someTrackingId";


### PR DESCRIPTION
## Summary
Adds support for configuring the IDV shortened flow by allowing relying parties to suppress specific screens in the Doc Scan / IDV session SDK config. A new `suppressed_screens` array is serialized on the `SdkConfig` payload, along with a `SuppressedScreen` constants class enumerating the valid values (`ID_DOCUMENT_EDUCATION`, `FLOW_COMPLETION`, etc.).

## Changes
- **`src/Yoti.Auth/DocScan/Session/Create/SuppressedScreen.cs`** (new): Constants class exposing the seven valid suppressible screen names.
- **`src/Yoti.Auth/DocScan/Session/Create/SdkConfig.cs`**: Adds `SuppressedScreens` property (serialized as `suppressed_screens`) and a new optional constructor argument.
- **`src/Yoti.Auth/DocScan/Session/Create/SdkConfigBuilder.cs`**: Adds `WithSuppressedScreens(List<string>)` (replaces the list) and `WithSuppressedScreen(string)` (appends a single value, lazily initialising the list).
- **`src/Yoti.Auth/Constants/DocScanConstants.cs`**: Adds the same screen-name constants under the nested constants scope for parity.
- **`test/Yoti.Auth.Tests/DocScan/Session/Create/SdkConfigBuilderTests.cs`**: 12 new tests covering null default, single-value and list-based configuration, JSON round-tripping, empty arrays, and forward-compatible handling of unknown screen values.
- **`test/Yoti.Auth.Tests/DocScan/Session/Create/SessionSpecificationBuilderTests.cs`**: New test verifying that `suppressed_screens` is serialized through to the full `SessionSpecification`.

## QA Test Steps
1. **Setup**: Check out the branch, restore NuGet packages, and build the solution (`dotnet build`).
2. **Run unit tests**: `dotnet test test/Yoti.Auth.Tests/Yoti.Auth.Tests.csproj --filter "FullyQualifiedName~SdkConfigBuilderTests|FullyQualifiedName~SessionSpecificationBuilderTests"` — all tests should pass, including the 13 new `SuppressedScreens*` tests.
3. **Happy path – list setter**: Build an `SdkConfig` via `new SdkConfigBuilder().WithSuppressedScreens(new List<string>{ SuppressedScreen.IdDocumentEducation, SuppressedScreen.FlowCompletion }).Build();`. Serialize via `JsonConvert.SerializeObject` and confirm the JSON contains `"suppressed_screens":["ID_DOCUMENT_EDUCATION","FLOW_COMPLETION"]`.
4. **Happy path – single setter**: Call `.WithSuppressedScreen(SuppressedScreen.FlowCompletion).WithSuppressedScreen(SuppressedScreen.IdDocumentRequirements)` on a fresh builder and confirm both entries appear, in order, on the built `SdkConfig.SuppressedScreens`.
5. **Default behaviour**: Build an `SdkConfig` without calling either suppressed-screen method. Confirm `SuppressedScreens` is `null` and that the serialized JSON (with `NullValueHandling.Ignore`) does not contain a `suppressed_screens` key — ensures non-shortened-flow callers are unaffected.
6. **Empty list**: Pass `new List<string>()` to `WithSuppressedScreens` and confirm the resulting property is a non-null empty list, serialized as `"suppressed_screens":[]`.
7. **Replacement semantics**: Call `WithSuppressedScreens(listA)` and then `WithSuppressedScreens(listB)` on the same builder; confirm only `listB` is retained (list setter replaces, it does not merge).
8. **End-to-end session spec**: Build a full `SessionSpecification` via `SessionSpecificationBuilder().WithSdkConfig(...)`. Confirm the serialized spec JSON contains `suppressed_screens` nested under `sdk_config`.
9. **Regression – existing SdkConfig fields**: Run the full `SdkConfigBuilderTests` suite and confirm the pre-existing tests (colours, capture methods, attempts configuration, handoff, etc.) still pass — verifies the new optional constructor parameter didn’t break existing call sites.
10. **Integration (optional, against IDV backend)**: Create a session with `suppressed_screens` set to `["ID_DOCUMENT_EDUCATION","FLOW_COMPLETION"]` and confirm the IDV UI flow omits those screens as expected.

## Notes
- The `SuppressedScreen` values are duplicated in both `SuppressedScreen` (public, intended as the canonical user-facing constants) and `DocScanConstants` (for internal parity with other screen-name constants). Consider consolidating to a single source in a follow-up if desired.
- Validation of screen names is intentionally deferred to the backend — the client accepts arbitrary strings, so newly introduced suppressible screens can be passed without an SDK release (verified by the `SuppressedScreensShouldDeserializeUnknownValuesGracefully` test).
- `WithSuppressedScreens(null)` will clear any previously configured list and cause `SuppressedScreens` to be omitted from JSON; this is the documented “opt-out” behaviour.
- No changes to the request/response contract beyond the new optional `suppressed_screens` field — fully backwards compatible with existing RP integrations.

---

*Related Jira:* SDK-2616
*Auto-generated by n8n + Claude CLI*