### PR TITLE
SDK-2806 Fix DigitalIdentityService QR-code URL construction

### DIFF
--- a/src/Yoti.Auth/DigitalIdentity/DigitalIdentityService.cs
+++ b/src/Yoti.Auth/DigitalIdentity/DigitalIdentityService.cs
@@ -102,6 +102,7 @@ namespace Yoti.Auth.DigitalIdentity
             Validation.NotNull(apiUrl, nameof(apiUrl));
             Validation.NotNull(sdkId, nameof(sdkId));
             Validation.NotNull(keyPair, nameof(keyPair));
+            Validation.NotNull(sessionId, nameof(sessionId));
 
             string serializedQrCode = JsonConvert.SerializeObject(
                 qrRequestPayload,

--- a/src/Yoti.Auth/DigitalIdentity/DigitalIdentityService.cs
+++ b/src/Yoti.Auth/DigitalIdentity/DigitalIdentityService.cs
@@ -116,7 +116,7 @@ namespace Yoti.Auth.DigitalIdentity
                 .WithKeyPair(keyPair)
                 .WithBaseUri(apiUrl)
                 .WithHeader(yotiAuthId, sdkId)
-                .WithEndpoint(string.Format($"/v2/sessions/{0}/qr-codes", sessionId))
+                .WithEndpoint($"/v2/sessions/{sessionId}/qr-codes")
                 .WithQueryParam("appId", sdkId)
                 .WithHttpMethod(HttpMethod.Post)
                 .WithContent(body)
@@ -148,7 +148,7 @@ namespace Yoti.Auth.DigitalIdentity
                 .WithKeyPair(keyPair)
                 .WithBaseUri(apiUrl)
                 .WithHeader(yotiAuthId, sdkId)
-                .WithEndpoint(string.Format($"/v2/qr-codes/{0}", qrCodeId))
+                .WithEndpoint($"/v2/qr-codes/{qrCodeId}")
                 .WithQueryParam("appId", sdkId)
                 .WithHttpMethod(HttpMethod.Get)
                 .Build();

--- a/test/Yoti.Auth.Tests/DigitalIdentityClientEngineTests.cs
+++ b/test/Yoti.Auth.Tests/DigitalIdentityClientEngineTests.cs
@@ -58,7 +58,7 @@ namespace Yoti.Auth.Tests
             Assert.IsNotNull(result);
             Assert.AreEqual(qrCodeId, result.Id);
             Assert.AreEqual(qrCodeUri, result.Uri);
-            Assert.IsTrue(_httpRequestMessage.RequestUri.AbsolutePath.Contains($"/v2/sessions/{sessionId}/qr-codes"));
+            Assert.IsTrue(_httpRequestMessage.RequestUri.AbsolutePath.EndsWith($"/v2/sessions/{sessionId}/qr-codes"));
         }
 
         [TestMethod]
@@ -80,7 +80,7 @@ namespace Yoti.Auth.Tests
             Assert.AreEqual(qrCodeId, result.Id);
             Assert.AreEqual(expiry, result.Expiry);
             Assert.AreEqual(policy, result.Policy);
-            Assert.IsTrue(_httpRequestMessage.RequestUri.AbsolutePath.Contains($"/v2/qr-codes/{qrCodeId}"));
+            Assert.IsTrue(_httpRequestMessage.RequestUri.AbsolutePath.EndsWith($"/v2/qr-codes/{qrCodeId}"));
         }
 
         [TestMethod]

--- a/test/Yoti.Auth.Tests/DigitalIdentityClientEngineTests.cs
+++ b/test/Yoti.Auth.Tests/DigitalIdentityClientEngineTests.cs
@@ -58,6 +58,7 @@ namespace Yoti.Auth.Tests
             Assert.IsNotNull(result);
             Assert.AreEqual(qrCodeId, result.Id);
             Assert.AreEqual(qrCodeUri, result.Uri);
+            Assert.IsTrue(_httpRequestMessage.RequestUri.AbsolutePath.Contains($"/v2/sessions/{sessionId}/qr-codes"));
         }
 
         [TestMethod]
@@ -79,6 +80,7 @@ namespace Yoti.Auth.Tests
             Assert.AreEqual(qrCodeId, result.Id);
             Assert.AreEqual(expiry, result.Expiry);
             Assert.AreEqual(policy, result.Policy);
+            Assert.IsTrue(_httpRequestMessage.RequestUri.AbsolutePath.Contains($"/v2/qr-codes/{qrCodeId}"));
         }
 
         [TestMethod]


### PR DESCRIPTION
## Summary

Fixes a regression introduced in `3.19.0` that made `DigitalIdentityService` completely non-functional.

`CreateQrCode` and `GetQrCode` built their endpoint URLs with `string.Format($"/v2/.../{0}", id)` — mixing an interpolated string (`$"..."`) with `string.Format` placeholders. The `{0}` is consumed by the C# interpolator first (rendering the integer literal `0`), so `string.Format` sees no placeholder and the `sessionId` / `qrCodeId` argument is silently dropped. Every request went to `/v2/sessions/0/qr-codes` or `/v2/qr-codes/0`.

Replaced with pure interpolation:
- `$"/v2/sessions/{sessionId}/qr-codes"`
- `$"/v2/qr-codes/{qrCodeId}"`

Also adds `RequestUri.AbsolutePath` assertions to the two existing tests in `DigitalIdentityClientEngineTests` so the same class of regression can't slip through silently again. (The tests already captured the outgoing request via `_httpRequestMessage` but never asserted on the URL.)

Related: closes the same bug as external PR #532 (which ships the fix without tests).