### PR TITLE
SDK-2738: .NET - Expose IDV breakdown "process" property - dotnet

### DIFF
--- a/src/Yoti.Auth/DocScan/Session/Retrieve/BreakdownResponse.cs
+++ b/src/Yoti.Auth/DocScan/Session/Retrieve/BreakdownResponse.cs
@@ -16,5 +16,8 @@ namespace Yoti.Auth.DocScan.Session.Retrieve
 
         [JsonProperty(PropertyName = "details")]
         public List<DetailsResponse> Details { get; private set; }
+
+        [JsonProperty(PropertyName = "process")]
+        public string Process { get; private set; }
     }
 }

--- a/test/Yoti.Auth.Tests/DocScan/Session/Retrieve/Check/CheckResponseTests.cs
+++ b/test/Yoti.Auth.Tests/DocScan/Session/Retrieve/Check/CheckResponseTests.cs
@@ -107,6 +107,56 @@ namespace Yoti.Auth.Tests.Docs.Session.Retrieve.Check
         }
 
         [TestMethod]
+        public void CheckBreakdownResponseProcessIsAutomated()
+        {
+            dynamic breakdownResponse = new
+            {
+                sub_check = "issuing_authority_verification",
+                result = "PASS",
+                process = "AUTOMATED",
+                details = new List<dynamic>()
+            };
+
+            string json = JsonConvert.SerializeObject(breakdownResponse);
+            BreakdownResponse response = JsonConvert.DeserializeObject<BreakdownResponse>(json);
+
+            Assert.AreEqual("AUTOMATED", response.Process);
+        }
+
+        [TestMethod]
+        public void CheckBreakdownResponseProcessIsExpertReview()
+        {
+            dynamic breakdownResponse = new
+            {
+                sub_check = "issuing_authority_verification",
+                result = "PASS",
+                process = "EXPERT_REVIEW",
+                details = new List<dynamic>()
+            };
+
+            string json = JsonConvert.SerializeObject(breakdownResponse);
+            BreakdownResponse response = JsonConvert.DeserializeObject<BreakdownResponse>(json);
+
+            Assert.AreEqual("EXPERT_REVIEW", response.Process);
+        }
+
+        [TestMethod]
+        public void CheckBreakdownResponseProcessIsNullWhenAbsent()
+        {
+            dynamic breakdownResponse = new
+            {
+                sub_check = "issuing_authority_verification",
+                result = "PASS",
+                details = new List<dynamic>()
+            };
+
+            string json = JsonConvert.SerializeObject(breakdownResponse);
+            BreakdownResponse response = JsonConvert.DeserializeObject<BreakdownResponse>(json);
+
+            Assert.IsNull(response.Process);
+        }
+
+        [TestMethod]
         public void CheckReportResponseIsParsed()
         {
             dynamic reportResponse = new
@@ -253,6 +303,7 @@ namespace Yoti.Auth.Tests.Docs.Session.Retrieve.Check
             {
                 sub_check = "issuing_authority_verification",
                 result = "PASS",
+                process = "AUTOMATED",
                 details = new List<dynamic> {
                     new { name = "n1", value = "v1" },
                     new { name = "n2", value = "v2" }
@@ -272,6 +323,7 @@ namespace Yoti.Auth.Tests.Docs.Session.Retrieve.Check
         {
             Assert.AreEqual(breakdownResponse.sub_check, response.SubCheck);
             Assert.AreEqual(breakdownResponse.result, response.Result);
+            Assert.AreEqual(breakdownResponse.process, response.Process);
 
             var detailsList = (breakdownResponse.details as IEnumerable<dynamic>);
             Assert.AreEqual(detailsList.First().name, response.Details.First().Name);


### PR DESCRIPTION
## Summary
Exposes the `process` property from the IDV (Identity Verification) breakdown API response in the .NET SDK. The `process` field indicates how a particular sub-check was handled (e.g., `AUTOMATED` or `EXPERT_REVIEW`) and was previously returned by the backend but silently dropped during deserialization. This change makes it accessible to SDK consumers via `BreakdownResponse.Process`.

## Changes
- **`src/Yoti.Auth/DocScan/Session/Retrieve/BreakdownResponse.cs`** — Added `Process` public property with `[JsonProperty("process")]` deserialization mapping, following the same pattern as existing `SubCheck`, `Result`, and `Details` properties.
- **`test/Yoti.Auth.Tests/DocScan/Session/Retrieve/Check/CheckResponseTests.cs`** — Added three new unit tests covering:
  - `CheckBreakdownResponseProcessIsAutomated` — verifies `"AUTOMATED"` is correctly deserialized.
  - `CheckBreakdownResponseProcessIsExpertReview` — verifies `"EXPERT_REVIEW"` is correctly deserialized.
  - `CheckBreakdownResponseProcessIsNullWhenAbsent` — verifies `Process` is `null` when the field is absent from the JSON payload.
  - Updated the shared helper `GetBreakdownResponse()` and `AssertBreakdownResponseValuesCorrect()` to include `process` in existing round-trip assertions.

## QA Test Steps
1. **Setup**: Check out branch `websdk-auto/SDK-2738-dotnet-expose-idv-breakdown-process-property` and restore NuGet packages (`dotnet restore`).
2. **Run the test suite**: Execute `dotnet test` (or run `CheckResponseTests` specifically) and confirm all tests pass, including the three new `CheckBreakdownResponseProcess*` tests.
3. **Happy path — `AUTOMATED`**: Simulate a `BreakdownResponse` JSON payload containing `"process": "AUTOMATED"` and assert `response.Process == "AUTOMATED"`. Covered by `CheckBreakdownResponseProcessIsAutomated`.
4. **Happy path — `EXPERT_REVIEW`**: Simulate a payload containing `"process": "EXPERT_REVIEW"` and assert `response.Process == "EXPERT_REVIEW"`. Covered by `CheckBreakdownResponseProcessIsExpertReview`.
5. **Edge case — missing field**: Simulate a payload with no `process` key (older API responses) and assert `response.Process == null`. Covered by `CheckBreakdownResponseProcessIsNullWhenAbsent`.
6. **Regression — existing breakdown parsing**: Run `CheckBreakdownResponseIsParsed` and all other existing `CheckResponseTests` to confirm no regressions were introduced in `SubCheck`, `Result`, and `Details` deserialization.
7. **Integration (if environment available)**: Retrieve a real IDV session via `GET /sessions/{sessionId}` from the DocScan API and traverse `session.Checks[*].Report.Breakdown[*].Process` to confirm the value is populated as expected from a live response.

## Notes
- The `Process` property is read-only (`private set`) and JSON-only, consistent with the rest of the `BreakdownResponse` model — there is no public setter and the field cannot be set programmatically.
- Known values at time of implementation are `"AUTOMATED"` and `"EXPERT_REVIEW"`, but the property is typed as `string` to handle any future values the backend may introduce without requiring an SDK update.
- No public API surface (interfaces, constructors, or serialization contracts) was changed; this is a purely additive, non-breaking change.
- No changes were required to the session retrieval or mapping layers — `BreakdownResponse` is deserialized directly from raw JSON by Newtonsoft.Json.

---

*Related Jira:* SDK-2738
*Auto-generated by n8n + Claude CLI*