### PR TITLE
SDK-2525-net-create-helper-methods-for-the-idv-sdk

### DIFF
--- a/src/Yoti.Auth/DocScan/Session/Retrieve/GetSessionResult.cs
+++ b/src/Yoti.Auth/DocScan/Session/Retrieve/GetSessionResult.cs
@@ -67,13 +67,16 @@ namespace Yoti.Auth.DocScan.Session.Retrieve
         /// </summary>
         /// <param name="checkId">The id of the check to find resources for</param>
         /// <returns>A ResourceContainer containing only the resources used by the check</returns>
-        /// <exception cref="ArgumentException">Thrown when no check with the given id is present</exception>
+        /// <exception cref="ArgumentException">Thrown when checkId is null or empty, or when no check with the given id is present</exception>
         public ResourceContainer GetResourcesForCheck(string checkId)
         {
-            CheckResponse checkResponse = Checks?.FirstOrDefault(check => check.Id != null && check.Id == checkId);
+            if (string.IsNullOrWhiteSpace(checkId))
+                throw new ArgumentException("Check id must not be null or empty", nameof(checkId));
+
+            CheckResponse checkResponse = Checks?.FirstOrDefault(check => check.Id == checkId);
 
             if (checkResponse == null)
-                throw new ArgumentException($"Check not found for check id: {checkId}");
+                throw new ArgumentException($"Check not found for check id: {checkId}", nameof(checkId));
 
             return Resources?.FilterForCheck(checkResponse) ?? new ResourceContainer();
         }

--- a/src/Yoti.Auth/DocScan/Session/Retrieve/GetSessionResult.cs
+++ b/src/Yoti.Auth/DocScan/Session/Retrieve/GetSessionResult.cs
@@ -61,7 +61,23 @@ namespace Yoti.Auth.DocScan.Session.Retrieve
 
         [JsonProperty(PropertyName = "advanced_identity_profile_preview")]
         public IdentityProfilePreviewResponse AdvancedIdentityProfilePreviewResponse { get; internal set; }
-        
+
+        /// <summary>
+        /// Returns the resources used by the check with the given check id
+        /// </summary>
+        /// <param name="checkId">The id of the check to find resources for</param>
+        /// <returns>A ResourceContainer containing only the resources used by the check</returns>
+        /// <exception cref="ArgumentException">Thrown when no check with the given id is present</exception>
+        public ResourceContainer GetResourcesForCheck(string checkId)
+        {
+            CheckResponse checkResponse = Checks?.FirstOrDefault(check => check.Id != null && check.Id == checkId);
+
+            if (checkResponse == null)
+                throw new ArgumentException($"Check not found for check id: {checkId}");
+
+            return Resources?.FilterForCheck(checkResponse) ?? new ResourceContainer();
+        }
+
         public List<AuthenticityCheckResponse> GetAuthenticityChecks()
         {
             if (Checks == null)

--- a/src/Yoti.Auth/DocScan/Session/Retrieve/Resource/ResourceContainer.cs
+++ b/src/Yoti.Auth/DocScan/Session/Retrieve/Resource/ResourceContainer.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
+using Yoti.Auth.DocScan.Session.Retrieve.Check;
 
 namespace Yoti.Auth.DocScan.Session.Retrieve.Resource
 {
@@ -63,6 +65,34 @@ namespace Yoti.Auth.DocScan.Session.Retrieve.Resource
 
                 return staticResources;
             }
+        }
+
+        /// <summary>
+        /// Returns a new <see cref="ResourceContainer"/> containing only the resources referenced by the given check's ResourcesUsed
+        /// </summary>
+        /// <param name="checkResponse">The check to filter resources for</param>
+        /// <returns>A ResourceContainer containing only the resources used by the check</returns>
+        internal ResourceContainer FilterForCheck(CheckResponse checkResponse)
+        {
+            List<string> resourceIds = checkResponse.ResourcesUsed ?? new List<string>();
+
+            return new ResourceContainer
+            {
+                IdDocuments = FilterResources(IdDocuments, resourceIds),
+                SupplementaryDocuments = FilterResources(SupplementaryDocuments, resourceIds),
+                LivenessCapture = FilterResources(LivenessCapture, resourceIds),
+                FaceCapture = FilterResources(FaceCapture, resourceIds),
+                ShareCodes = FilterResources(ShareCodes, resourceIds),
+                ApplicantProfiles = FilterResources(ApplicantProfiles, resourceIds)
+            };
+        }
+
+        private static List<T> FilterResources<T>(List<T> resources, List<string> resourceIds) where T : ResourceResponse
+        {
+            if (resources == null)
+                return new List<T>();
+
+            return resources.Where(resource => resourceIds.Contains(resource.Id)).ToList();
         }
     }
 }

--- a/src/Yoti.Auth/DocScan/Session/Retrieve/Resource/ResourceContainer.cs
+++ b/src/Yoti.Auth/DocScan/Session/Retrieve/Resource/ResourceContainer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
 using Yoti.Auth.DocScan.Session.Retrieve.Check;
@@ -74,7 +75,10 @@ namespace Yoti.Auth.DocScan.Session.Retrieve.Resource
         /// <returns>A ResourceContainer containing only the resources used by the check</returns>
         internal ResourceContainer FilterForCheck(CheckResponse checkResponse)
         {
-            List<string> resourceIds = checkResponse.ResourcesUsed ?? new List<string>();
+            if (checkResponse == null)
+                throw new ArgumentNullException(nameof(checkResponse));
+
+            HashSet<string> resourceIds = new HashSet<string>(checkResponse.ResourcesUsed ?? new List<string>());
 
             return new ResourceContainer
             {
@@ -87,7 +91,7 @@ namespace Yoti.Auth.DocScan.Session.Retrieve.Resource
             };
         }
 
-        private static List<T> FilterResources<T>(List<T> resources, List<string> resourceIds) where T : ResourceResponse
+        private static List<T> FilterResources<T>(List<T> resources, HashSet<string> resourceIds) where T : ResourceResponse
         {
             if (resources == null)
                 return new List<T>();

--- a/test/Yoti.Auth.Tests/DocScan/Session/Retrieve/GetSessionResultTests.cs
+++ b/test/Yoti.Auth.Tests/DocScan/Session/Retrieve/GetSessionResultTests.cs
@@ -8,6 +8,7 @@ using Yoti.Auth.DocScan.Session.Retrieve.AdvancedIdentityProfile;
 using Yoti.Auth.DocScan.Session.Retrieve.AdvancedIdentityProfilePreview;
 using Yoti.Auth.DocScan.Session.Retrieve.Check;
 using Yoti.Auth.DocScan.Session.Retrieve.IdentityProfilePreview;
+using Yoti.Auth.DocScan.Session.Retrieve.Resource;
 
 namespace Yoti.Auth.Tests.DocScan.Session.Retrieve
 {
@@ -407,6 +408,78 @@ namespace Yoti.Auth.Tests.DocScan.Session.Retrieve
             };
 
             Assert.AreEqual(2, getSessionResult.Checks.Count);
+        }
+
+        [TestMethod]
+        public void GetResourcesForCheckShouldThrowWhenCheckIdNotFound()
+        {
+            var getSessionResult = new GetSessionResult
+            {
+                Checks = new List<CheckResponse>
+                {
+                    new AuthenticityCheckResponse { Id = "check-1" }
+                }
+            };
+
+            Assert.ThrowsException<ArgumentException>(() => getSessionResult.GetResourcesForCheck("unknown-check-id"));
+        }
+
+        [TestMethod]
+        public void GetResourcesForCheckShouldReturnOnlyResourcesUsedByCheck()
+        {
+            var idDocument = new IdDocumentResourceResponse { Id = "id-document-1" };
+            var otherIdDocument = new IdDocumentResourceResponse { Id = "id-document-2" };
+
+            var getSessionResult = new GetSessionResult
+            {
+                Checks = new List<CheckResponse>
+                {
+                    new AuthenticityCheckResponse
+                    {
+                        Id = "check-1",
+                        ResourcesUsed = new List<string> { "id-document-1" }
+                    }
+                },
+                Resources = new ResourceContainer
+                {
+                    IdDocuments = new List<IdDocumentResourceResponse> { idDocument, otherIdDocument }
+                }
+            };
+
+            var result = getSessionResult.GetResourcesForCheck("check-1");
+
+            Assert.AreEqual(1, result.IdDocuments.Count);
+            Assert.AreEqual("id-document-1", result.IdDocuments.First().Id);
+        }
+
+        [TestMethod]
+        public void GetResourcesForCheckShouldThrowWhenCheckIdIsNullEvenIfACheckHasNullId()
+        {
+            var getSessionResult = new GetSessionResult
+            {
+                Checks = new List<CheckResponse>
+                {
+                    new AuthenticityCheckResponse()
+                }
+            };
+
+            Assert.ThrowsException<ArgumentException>(() => getSessionResult.GetResourcesForCheck(null));
+        }
+
+        [TestMethod]
+        public void GetResourcesForCheckShouldReturnEmptyResourceContainerWhenResourcesIsNull()
+        {
+            var getSessionResult = new GetSessionResult
+            {
+                Checks = new List<CheckResponse>
+                {
+                    new AuthenticityCheckResponse { Id = "check-1" }
+                }
+            };
+
+            var result = getSessionResult.GetResourcesForCheck("check-1");
+
+            Assert.IsNotNull(result);
         }
     }
 }

--- a/test/Yoti.Auth.Tests/DocScan/Session/Retrieve/GetSessionResultTests.cs
+++ b/test/Yoti.Auth.Tests/DocScan/Session/Retrieve/GetSessionResultTests.cs
@@ -411,6 +411,22 @@ namespace Yoti.Auth.Tests.DocScan.Session.Retrieve
         }
 
         [TestMethod]
+        public void GetResourcesForCheckShouldThrowWhenCheckIdIsNullOrWhitespace()
+        {
+            var getSessionResult = new GetSessionResult
+            {
+                Checks = new List<CheckResponse>
+                {
+                    new AuthenticityCheckResponse { Id = "check-1" }
+                }
+            };
+
+            Assert.ThrowsException<ArgumentException>(() => getSessionResult.GetResourcesForCheck(null));
+            Assert.ThrowsException<ArgumentException>(() => getSessionResult.GetResourcesForCheck(string.Empty));
+            Assert.ThrowsException<ArgumentException>(() => getSessionResult.GetResourcesForCheck("   "));
+        }
+
+        [TestMethod]
         public void GetResourcesForCheckShouldThrowWhenCheckIdNotFound()
         {
             var getSessionResult = new GetSessionResult
@@ -450,20 +466,6 @@ namespace Yoti.Auth.Tests.DocScan.Session.Retrieve
 
             Assert.AreEqual(1, result.IdDocuments.Count);
             Assert.AreEqual("id-document-1", result.IdDocuments.First().Id);
-        }
-
-        [TestMethod]
-        public void GetResourcesForCheckShouldThrowWhenCheckIdIsNullEvenIfACheckHasNullId()
-        {
-            var getSessionResult = new GetSessionResult
-            {
-                Checks = new List<CheckResponse>
-                {
-                    new AuthenticityCheckResponse()
-                }
-            };
-
-            Assert.ThrowsException<ArgumentException>(() => getSessionResult.GetResourcesForCheck(null));
         }
 
         [TestMethod]

--- a/test/Yoti.Auth.Tests/DocScan/Session/Retrieve/Resource/ResourceContainerTests.cs
+++ b/test/Yoti.Auth.Tests/DocScan/Session/Retrieve/Resource/ResourceContainerTests.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Yoti.Auth.DocScan.Session.Retrieve;
+using Yoti.Auth.DocScan.Session.Retrieve.Check;
+using Yoti.Auth.DocScan.Session.Retrieve.Resource;
+
+namespace Yoti.Auth.Tests.DocScan.Session.Retrieve.Resource
+{
+    [TestClass]
+    public class ResourceContainerTests
+    {
+        [TestMethod]
+        public void FilterForCheckShouldHandleNullResourceLists()
+        {
+            var resourceContainer = new ResourceContainer();
+            var checkResponse = new AuthenticityCheckResponse { ResourcesUsed = new List<string> { "some-resource-id" } };
+
+            var result = resourceContainer.FilterForCheck(checkResponse);
+
+            Assert.AreEqual(0, result.IdDocuments.Count);
+            Assert.AreEqual(0, result.SupplementaryDocuments.Count);
+            Assert.AreEqual(0, result.LivenessCapture.Count);
+            Assert.AreEqual(0, result.FaceCapture.Count);
+            Assert.AreEqual(0, result.ShareCodes.Count);
+            Assert.AreEqual(0, result.ApplicantProfiles.Count);
+        }
+
+        [TestMethod]
+        public void FilterForCheckShouldHandleNullResourcesUsed()
+        {
+            var resourceContainer = new ResourceContainer
+            {
+                IdDocuments = new List<IdDocumentResourceResponse> { new IdDocumentResourceResponse { Id = "id-document-1" } }
+            };
+            var checkResponse = new AuthenticityCheckResponse();
+
+            var result = resourceContainer.FilterForCheck(checkResponse);
+
+            Assert.AreEqual(0, result.IdDocuments.Count);
+        }
+
+        [TestMethod]
+        public void FilterForCheckShouldReturnOnlyResourcesReferencedByCheck()
+        {
+            var idDocument1 = new IdDocumentResourceResponse { Id = "id-document-1" };
+            var idDocument2 = new IdDocumentResourceResponse { Id = "id-document-2" };
+            var supplementaryDocument1 = new SupplementaryDocResourceResponse { Id = "supplementary-document-1" };
+            var supplementaryDocument2 = new SupplementaryDocResourceResponse { Id = "supplementary-document-2" };
+            var liveness1 = new ZoomLivenessResourceResponse { Id = "liveness-1" };
+            var liveness2 = new StaticLivenessResourceResponse { Id = "liveness-2" };
+            var faceCapture1 = new FaceCaptureResourceResponse { Id = "face-capture-1" };
+            var faceCapture2 = new FaceCaptureResourceResponse { Id = "face-capture-2" };
+            var shareCode1 = new ShareCodeResourceResponse { Id = "share-code-1" };
+            var shareCode2 = new ShareCodeResourceResponse { Id = "share-code-2" };
+            var applicantProfile1 = new ApplicantProfileResourceResponse { Id = "applicant-profile-1" };
+            var applicantProfile2 = new ApplicantProfileResourceResponse { Id = "applicant-profile-2" };
+
+            var resourceContainer = new ResourceContainer
+            {
+                IdDocuments = new List<IdDocumentResourceResponse> { idDocument1, idDocument2 },
+                SupplementaryDocuments = new List<SupplementaryDocResourceResponse> { supplementaryDocument1, supplementaryDocument2 },
+                LivenessCapture = new List<LivenessResourceResponse> { liveness1, liveness2 },
+                FaceCapture = new List<FaceCaptureResourceResponse> { faceCapture1, faceCapture2 },
+                ShareCodes = new List<ShareCodeResourceResponse> { shareCode1, shareCode2 },
+                ApplicantProfiles = new List<ApplicantProfileResourceResponse> { applicantProfile1, applicantProfile2 }
+            };
+
+            var checkResponse = new AuthenticityCheckResponse
+            {
+                ResourcesUsed = new List<string>
+                {
+                    "id-document-1",
+                    "supplementary-document-1",
+                    "liveness-1",
+                    "face-capture-1",
+                    "share-code-1",
+                    "applicant-profile-1"
+                }
+            };
+
+            var result = resourceContainer.FilterForCheck(checkResponse);
+
+            CollectionAssert.AreEqual(new[] { idDocument1 }, result.IdDocuments);
+            CollectionAssert.AreEqual(new[] { supplementaryDocument1 }, result.SupplementaryDocuments);
+            CollectionAssert.AreEqual(new[] { liveness1 }, result.LivenessCapture);
+            CollectionAssert.AreEqual(new[] { faceCapture1 }, result.FaceCapture);
+            CollectionAssert.AreEqual(new[] { shareCode1 }, result.ShareCodes);
+            CollectionAssert.AreEqual(new[] { applicantProfile1 }, result.ApplicantProfiles);
+        }
+    }
+}

--- a/test/Yoti.Auth.Tests/DocScan/Session/Retrieve/Resource/ResourceContainerTests.cs
+++ b/test/Yoti.Auth.Tests/DocScan/Session/Retrieve/Resource/ResourceContainerTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Yoti.Auth.DocScan.Session.Retrieve;
@@ -9,6 +10,14 @@ namespace Yoti.Auth.Tests.DocScan.Session.Retrieve.Resource
     [TestClass]
     public class ResourceContainerTests
     {
+        [TestMethod]
+        public void FilterForCheckShouldThrowWhenCheckResponseIsNull()
+        {
+            var resourceContainer = new ResourceContainer();
+
+            Assert.ThrowsException<ArgumentNullException>(() => resourceContainer.FilterForCheck(null));
+        }
+
         [TestMethod]
         public void FilterForCheckShouldHandleNullResourceLists()
         {


### PR DESCRIPTION
## Summary

Adds helper methods so a Relying Business can look up which Resources (id documents, supplementary documents, liveness captures, face captures, share codes, applicant profiles) belong to a given Check, without having to manually cross-reference `CheckResponse.ResourcesUsed` against `ResourceContainer` themselves.

### Changes

- `GetSessionResult.GetResourcesForCheck(string checkId)` — public method that finds the `CheckResponse` with the given id and returns a `ResourceContainer` containing only the resources it used.
  - Throws `ArgumentException` (with `nameof(checkId)`) if `checkId` is null/empty/whitespace, or if no check with that id exists.
  - Returns an empty `ResourceContainer` if the session has no `Resources` at all (e.g. `resources` key absent from the response).
- `ResourceContainer.FilterForCheck(CheckResponse checkResponse)` (internal) — filters all six resource lists (`IdDocuments`, `SupplementaryDocuments`, `LivenessCapture`, `FaceCapture`, `ShareCodes`, `ApplicantProfiles`) down to only the ids referenced in the check's `ResourcesUsed`, using a `HashSet<string>` for O(1) membership checks.
  - Throws `ArgumentNullException` if `checkResponse` is null.

### Notes

-  filters `ShareCodes` too since the .NET SDK already supports share code resources (SDK-2753).
- `FilterForCheck` is `internal` (via `InternalsVisibleTo`)